### PR TITLE
cassandra excpects ascii encoding

### DIFF
--- a/lib/superstore/adapters/cassandra_adapter.rb
+++ b/lib/superstore/adapters/cassandra_adapter.rb
@@ -169,7 +169,7 @@ module Superstore
       private
 
         def sanitize(statement, *bind_vars)
-          CassandraCQL::Statement.sanitize(statement, bind_vars).force_encoding(Encoding::UTF_8)
+          CassandraCQL::Statement.sanitize(statement, bind_vars)
         end
 
         def quote_columns(column_names)


### PR DESCRIPTION
don't force utf8 because cassandra excpects ascii encoding

@matthuhiggins 
