### PR TITLE
More forgiving type conversion.

### DIFF
--- a/lib/superstore/types/float_type.rb
+++ b/lib/superstore/types/float_type.rb
@@ -3,12 +3,10 @@ module Superstore
     class FloatType < BaseType
       REGEX = /\A[-+]?\d+(\.\d+)?\Z/
       def encode(float)
-        raise ArgumentError.new("#{float.inspect} is not a Float") unless float.kind_of?(Float)
-
         if model.config[:adapter] == 'jsonb'
-          float
+          Float(float)
         else
-          float.to_s
+          Float(float).to_s
         end
       end
 

--- a/lib/superstore/types/integer_type.rb
+++ b/lib/superstore/types/integer_type.rb
@@ -3,12 +3,10 @@ module Superstore
     class IntegerType < BaseType
       REGEX = /\A[-+]?\d+\Z/
       def encode(int)
-        raise ArgumentError.new("#{int.inspect} is not an Integer.") unless int.kind_of?(Integer)
-
         if model.config[:adapter] == 'jsonb'
-          int
+          Integer(int)
         else
-          int.to_s
+          Integer(int).to_s
         end
       end
 


### PR DESCRIPTION
The value 4996 is an integer and can be a valid Float. This will convert it instead of raising an error. If it can't be safely converted, the `Float` and `Integer` methods raise an `ArgumentError` the same way this code did.

@matthuhiggins 