### PR TITLE
Use a cursor to implement find_each

### DIFF
--- a/lib/superstore/scope/batches.rb
+++ b/lib/superstore/scope/batches.rb
@@ -2,29 +2,27 @@ module Superstore
   class Scope
     module Batches
       def find_each(options = {})
-        find_in_batches(options) do |records|
-          records.each { |record| yield record }
+        batch_size = options[:batch_size] || 1000
+
+        klass.adapter.scroll(self, batch_size) do |key, attributes|
+          yield klass.instantiate(key, attributes)
         end
       end
 
       def find_in_batches(options = {})
-        batch_size = options.delete(:batch_size) || 1000
+        batch_size = options[:batch_size] || 1000
+        batch = []
 
-        scope = limit(batch_size + 1).order(:id)
-        records = scope.to_a
+        find_each(options) do |record|
+          batch << record
 
-        while records.any?
-          if records.size > batch_size
-            next_record = records.pop
-          else
-             next_record = nil
+          if batch.size == batch_size
+            yield batch
+            batch = []
           end
-
-          yield records
-          break if next_record.nil?
-
-          records = scope.where("#{adapter.primary_key_column} >= '#{next_record.id}'").to_a
         end
+
+        yield(batch) if batch.any?
       end
     end
   end


### PR DESCRIPTION
This changes the implementation of `find_each` to use a cursor. It makes it much much faster. The normal `find_each` implementation calculates a new SELECT statement for each batch, which always has an `order(:id)` and generally has a WHERE clause.

I am thinking that this can be called `scroll_each` and `scroll_in_batches` instead.

@data-axle/developers 