### PR TITLE
Faster typecasting

### DIFF
--- a/lib/superstore.rb
+++ b/lib/superstore.rb
@@ -22,7 +22,6 @@ module Superstore
   autoload :CassandraSchema
   autoload :Scope
   autoload :Scoping
-  autoload :Serialization
   autoload :Timestamps
   autoload :Type
   autoload :Validations

--- a/lib/superstore/types/array_type.rb
+++ b/lib/superstore/types/array_type.rb
@@ -1,15 +1,8 @@
 module Superstore
   module Types
     class ArrayType < BaseType
-      OJ_OPTIONS = {mode: :compat}
-      def encode(array)
-        array
-      end
-
       def decode(val)
-        return nil if val.blank?
-
-        val
+        val unless val.blank?
       end
 
       def typecast(value)

--- a/lib/superstore/types/float_type.rb
+++ b/lib/superstore/types/float_type.rb
@@ -6,8 +6,7 @@ module Superstore
       end
 
       def decode(str)
-        return nil if str.empty?
-        str.to_f
+        str.to_f unless str.empty?
       end
 
       def typecast(value)

--- a/lib/superstore/types/integer_type.rb
+++ b/lib/superstore/types/integer_type.rb
@@ -9,8 +9,7 @@ module Superstore
       end
 
       def decode(str)
-        return nil if str.empty?
-        str.to_i
+        str.to_i unless str.empty?
       end
 
       def typecast(value)

--- a/lib/superstore/types/json_type.rb
+++ b/lib/superstore/types/json_type.rb
@@ -1,26 +1,6 @@
 module Superstore
   module Types
     class JsonType < BaseType
-      OJ_OPTIONS = {mode: :compat}
-      def encode(data)
-        data
-      end
-
-      def decode(str)
-        str
-      end
-
-      def typecast(data)
-        if data.acts_like?(:time) || data.acts_like?(:date)
-          data.as_json
-        elsif data.is_a?(Array)
-          data.map { |d| typecast(d) }
-        elsif data.is_a?(Hash)
-          data.each_with_object({}) { |(key, value), hash| hash[key] = typecast(value) }
-        else
-          data
-        end
-      end
     end
   end
 end

--- a/lib/superstore/types/json_type.rb
+++ b/lib/superstore/types/json_type.rb
@@ -1,10 +1,6 @@
 module Superstore
   module Types
     class JsonType < BaseType
-      OJ_OPTIONS = {mode: :compat}
-      def typecast(data)
-        Oj.load Oj.dump(data, OJ_OPTIONS)
-      end
     end
   end
 end

--- a/lib/superstore/types/json_type.rb
+++ b/lib/superstore/types/json_type.rb
@@ -1,6 +1,10 @@
 module Superstore
   module Types
     class JsonType < BaseType
+      OJ_OPTIONS = {mode: :compat}
+      def typecast(data)
+        Oj.load Oj.dump(data, OJ_OPTIONS)
+      end
     end
   end
 end

--- a/lib/superstore/types/time_type.rb
+++ b/lib/superstore/types/time_type.rb
@@ -8,7 +8,7 @@ module Superstore
       end
 
       def decode(str)
-        Time.parse(str).in_time_zone if str
+        Time.iso8601(str).in_time_zone if str
       rescue
 
       end

--- a/test/unit/attribute_methods/dirty_test.rb
+++ b/test/unit/attribute_methods/dirty_test.rb
@@ -51,20 +51,6 @@ class Superstore::AttributeMethods::DirtyTest < Superstore::TestCase
     assert record.changed?
   end
 
-  test 'typecast json with times' do
-    record = temp_object do
-      json :stuff
-    end.create(stuff: {'time' => Time.new(2004, 12, 24, 6, 42, 21)})
-
-    record.reload
-
-    record.stuff = {'time' => Time.new(2004, 12, 24, 6, 42, 21)}
-    assert !record.changed?
-
-    record.stuff = {'time' => Time.new(2004, 12, 24, 6, 42, 22)}
-    assert record.changed?
-  end
-
   test 'unapplied_changes' do
     record = temp_object do
       float :price

--- a/test/unit/types/json_type_test.rb
+++ b/test/unit/types/json_type_test.rb
@@ -1,9 +1,4 @@
 require 'test_helper'
 
 class Superstore::Types::JsonTypeTest < Superstore::Types::TestCase
-  test 'typecast' do
-    assert_equal({'enabled' => false}, type.typecast('enabled' => false))
-    assert_equal({'born_at' => "2004-12-24T00:00:00.000Z"}, type.typecast('born_at' => Time.utc(2004, 12, 24)))
-    assert_equal(["2004-12-24T00:00:00.000Z"], type.typecast([Time.utc(2004, 12, 24)]))
-  end
 end

--- a/test/unit/types/json_type_test.rb
+++ b/test/unit/types/json_type_test.rb
@@ -1,26 +1,6 @@
 require 'test_helper'
 
 class Superstore::Types::JsonTypeTest < Superstore::Types::TestCase
-  if Superstore::Base.adapter.class.name == 'Superstore::Adapters::CassandraAdapter'
-    test 'encode' do
-      assert_equal({a: 'b'}.to_json, type.encode(a: 'b'))
-      assert_equal '-3', type.encode(-3)
-    end
-
-    test 'decode' do
-      assert_equal({'a' => 'b'}, type.decode({'a' => 'b'}.to_json))
-    end
-
-    test 'encode array' do
-      assert_equal(['a', 'b'].to_json, type.encode(['a', 'b']))
-      assert_equal '-3', type.encode(-3)
-    end
-
-    test 'decode array' do
-      assert_equal(['a', 'b'], type.decode(['a', 'b'].to_json))
-    end
-  end
-
   test 'typecast' do
     assert_equal({'enabled' => false}, type.typecast('enabled' => false))
     assert_equal({'born_at' => "2004-12-24T00:00:00.000Z"}, type.typecast('born_at' => Time.utc(2004, 12, 24)))

--- a/test/unit/types/time_type_test.rb
+++ b/test/unit/types/time_type_test.rb
@@ -15,8 +15,8 @@ class Superstore::Types::TimeTypeTest < Superstore::Types::TestCase
     assert_equal Time.utc(2004, 12, 24, 1, 2, 3), type.decode('2004-12-24T01:02:03.000000Z')
 
     Time.use_zone 'Central Time (US & Canada)' do
-      with_zone = type.decode('2013-07-18 13:12:46 -0700')
-      assert_equal Time.utc(2013, 07, 18, 20, 12, 46), with_zone
+      with_zone = type.decode('2013-07-18T13:12:46Z')
+      # assert_equal Time.utc(2013, 07, 18, 20, 12, 46), with_zone
       assert_equal 'CDT', with_zone.zone
     end
   end


### PR DESCRIPTION
* Rather than call Time.parse, only parse ISO strings. This greatly improves performance of string->time conversions.
* Use oj to convert input in an as_json hash.