### PR TITLE
Use active record associations

### DIFF
--- a/lib/superstore/associations.rb
+++ b/lib/superstore/associations.rb
@@ -53,7 +53,7 @@ module Superstore
     end
 
     private
-      def clear_associations_cache
+      def clear_association_cache
         associations_cache.clear if persisted?
       end
 

--- a/lib/superstore/associations.rb
+++ b/lib/superstore/associations.rb
@@ -2,11 +2,6 @@ module Superstore
   module Associations
     extend ActiveSupport::Concern
 
-    included do
-      class_attribute :association_reflections
-      self.association_reflections = {}
-    end
-
     module ClassMethods
       # === Options
       # [:class_name]
@@ -19,54 +14,29 @@ module Superstore
       #   class Truck < Superstore::Base
       #   end
       def belongs_to(name, options = {})
-        Superstore::Associations::Builder::BelongsTo.build(self, name, options)
+        if options.delete(:superstore)
+          Superstore::Associations::Builder::BelongsTo.build(self, name, options)
+        else
+          super
+        end
       end
 
       def has_many(name, options = {})
-        Superstore::Associations::Builder::HasMany.build(self, name, options)
+        if options.delete(:superstore)
+          Superstore::Associations::Builder::HasMany.build(self, name, options)
+        else
+          super
+        end
       end
 
       def has_one(name, options = {})
-        Superstore::Associations::Builder::HasOne.build(self, name, options)
-      end
-
-      def generated_association_methods
-        @generated_association_methods ||= begin
-          mod = const_set(:GeneratedAssociationMethods, Module.new)
-          include mod
-          mod
+        if options.delete(:superstore)
+          Superstore::Associations::Builder::HasOne.build(self, name, options)
+        else
+          super
         end
       end
     end
 
-    # Returns the belongs_to instance for the given name, instantiating it if it doesn't already exist
-    def association(name)
-      instance = association_instance_get(name)
-
-      if instance.nil?
-        reflection = association_reflections[name]
-        instance = reflection.association_class.new(self, reflection)
-        association_instance_set(name, instance)
-      end
-
-      instance
-    end
-
-    private
-      def clear_association_cache
-        associations_cache.clear if persisted?
-      end
-
-      def associations_cache
-        @associations_cache ||= {}
-      end
-
-      def association_instance_get(name)
-        associations_cache[name.to_sym]
-      end
-
-      def association_instance_set(name, association)
-        associations_cache[name.to_sym] = association
-      end
   end
 end

--- a/lib/superstore/associations/builder/association.rb
+++ b/lib/superstore/associations/builder/association.rb
@@ -14,7 +14,7 @@ module Superstore::Associations::Builder
       define_reader
 
       reflection = Superstore::Associations::Reflection.new(macro, name, model, options)
-      model.association_reflections = model.association_reflections.merge(name => reflection)
+      ActiveRecord::Reflection.add_reflection model, name, reflection
     end
 
     def mixin

--- a/lib/superstore/associations/has_many.rb
+++ b/lib/superstore/associations/has_many.rb
@@ -16,7 +16,7 @@ module Superstore
         relation.instance_variable_set :@records, records
         relation.instance_variable_set :@loaded, true
 
-        self.target = load_collection
+        self.target = relation
       end
 
       private
@@ -24,6 +24,8 @@ module Superstore
         def load_collection
           association_class.where(reflection.foreign_key => owner.try(reflection.primary_key))
         end
+
+        ActiveRecord::AssociationRelation.create(association_class, association_class.arel_table, association_class.predicate_builder, self)
 
     end
   end

--- a/lib/superstore/associations/has_many.rb
+++ b/lib/superstore/associations/has_many.rb
@@ -25,8 +25,6 @@ module Superstore
           association_class.where(reflection.foreign_key => owner.try(reflection.primary_key))
         end
 
-        ActiveRecord::AssociationRelation.create(association_class, association_class.arel_table, association_class.predicate_builder, self)
-
     end
   end
 end

--- a/lib/superstore/attribute_methods.rb
+++ b/lib/superstore/attribute_methods.rb
@@ -33,6 +33,10 @@ module Superstore
       def attribute_methods_generated?
         @attribute_methods_generated ||= false
       end
+
+      def dangerous_attribute_method?(name)
+        false
+      end
     end
 
     def write_attribute(name, value)
@@ -40,8 +44,15 @@ module Superstore
     end
 
     def read_attribute(name)
-      @attributes[name.to_s]
+      name = name.to_s unless name.is_a?(String)
+
+      if name == self.class.primary_key
+        send(name)
+      else
+        @attributes[name]
+      end
     end
+    alias_method :_read_attribute, :read_attribute
 
     def attribute_exists?(name)
       @attributes.key?(name.to_s)

--- a/lib/superstore/attribute_methods.rb
+++ b/lib/superstore/attribute_methods.rb
@@ -54,6 +54,11 @@ module Superstore
     end
     alias_method :_read_attribute, :read_attribute
 
+    def attribute_present?(attribute)
+      value = _read_attribute(attribute)
+      !value.nil? && !(value.respond_to?(:empty?) && value.empty?)
+    end
+
     def attribute_exists?(name)
       @attributes.key?(name.to_s)
     end

--- a/lib/superstore/attribute_methods/primary_key.rb
+++ b/lib/superstore/attribute_methods/primary_key.rb
@@ -4,8 +4,9 @@ module Superstore
       extend ActiveSupport::Concern
 
       module ClassMethods
+        PRIMARY_KEY = 'id'
         def primary_key
-          'id'
+          PRIMARY_KEY
         end
       end
 

--- a/lib/superstore/base.rb
+++ b/lib/superstore/base.rb
@@ -11,6 +11,17 @@ module Superstore
     include ActiveModel::Serializers::JSON
     include GlobalID::Identification
 
+    extend ActiveRecord::Delegation::DelegateCache
+    extend ActiveRecord::ConnectionHandling
+    # include ActiveRecord::Core
+    include ActiveRecord::ModelSchema
+    include ActiveRecord::Inheritance
+    include ActiveRecord::Scoping
+    include ActiveRecord::Attributes
+    include ActiveRecord::Associations
+    include ActiveRecord::AutosaveAssociation
+    include ActiveRecord::Reflection
+
     include Model
     include Core
     include Connection
@@ -22,7 +33,7 @@ module Superstore
     include AttributeMethods::Dirty
     include AttributeMethods::PrimaryKey
     include AttributeMethods::Typecasting
-    include Associations
+    # include Associations
     include Callbacks
     include Timestamps
     include Scoping

--- a/lib/superstore/base.rb
+++ b/lib/superstore/base.rb
@@ -13,10 +13,8 @@ module Superstore
 
     extend ActiveRecord::Delegation::DelegateCache
     extend ActiveRecord::ConnectionHandling
-    # include ActiveRecord::Core
     include ActiveRecord::ModelSchema
     include ActiveRecord::Inheritance
-    include ActiveRecord::Scoping
     include ActiveRecord::Attributes
     include ActiveRecord::Associations
     include ActiveRecord::AutosaveAssociation
@@ -33,7 +31,7 @@ module Superstore
     include AttributeMethods::Dirty
     include AttributeMethods::PrimaryKey
     include AttributeMethods::Typecasting
-    # include Associations
+    include Associations
     include Callbacks
     include Timestamps
     include Scoping

--- a/lib/superstore/connection.rb
+++ b/lib/superstore/connection.rb
@@ -15,6 +15,10 @@ module Superstore
           raise "Unknown adapter #{config[:adapter]}"
         end
       end
+
+      def connection
+        adapter.connection
+      end
     end
   end
 end

--- a/lib/superstore/core.rb
+++ b/lib/superstore/core.rb
@@ -27,16 +27,10 @@ module Superstore
       def arel_table # :nodoc:
         @arel_table ||= Arel::Table.new(table_name, self)
       end
-      #
-      # # Returns the Arel engine.
-      # def arel_engine # :nodoc:
-      #   @arel_engine ||=
-      #     if Base == self || connection_handler.retrieve_connection_pool(self)
-      #       self
-      #     else
-      #       superclass.arel_engine
-      #     end
-      # end
+
+      def subclass_from_attributes?(attrs)
+        false
+      end
     end
 
     def initialize(attributes=nil)

--- a/lib/superstore/model.rb
+++ b/lib/superstore/model.rb
@@ -5,16 +5,19 @@ module Superstore
     included do
       class_attribute :symbolized_config
       self.symbolized_config = {}
+
+      # class_attribute :pluralize_table_names, instance_writer: false
+      # self.pluralize_table_names = true
     end
 
     module ClassMethods
-      def table_name=(table_name)
-        @table_name = table_name
-      end
-
-      def table_name
-        @table_name ||= base_class.model_name.plural
-      end
+      # def table_name=(table_name)
+      #   @table_name = table_name
+      # end
+      #
+      # def table_name
+      #   @table_name ||= base_class.model_name.plural
+      # end
 
       def base_class
         class_of_active_record_descendant(self)

--- a/lib/superstore/model.rb
+++ b/lib/superstore/model.rb
@@ -5,20 +5,9 @@ module Superstore
     included do
       class_attribute :symbolized_config
       self.symbolized_config = {}
-
-      # class_attribute :pluralize_table_names, instance_writer: false
-      # self.pluralize_table_names = true
     end
 
     module ClassMethods
-      # def table_name=(table_name)
-      #   @table_name = table_name
-      # end
-      #
-      # def table_name
-      #   @table_name ||= base_class.model_name.plural
-      # end
-
       def base_class
         class_of_active_record_descendant(self)
       end

--- a/lib/superstore/persistence.rb
+++ b/lib/superstore/persistence.rb
@@ -43,6 +43,7 @@ module Superstore
           object.instance_variable_set("@new_record", false)
           object.instance_variable_set("@destroyed", false)
           object.instance_variable_set("@attributes", typecast_persisted_attributes(attributes))
+          object.instance_variable_set("@association_cache", {})
         end
       end
 
@@ -127,7 +128,7 @@ module Superstore
     end
 
     def reload
-      clear_associations_cache
+      clear_association_cache
       @attributes = self.class.find(id).instance_variable_get('@attributes')
       self
     end

--- a/lib/superstore/scoping.rb
+++ b/lib/superstore/scoping.rb
@@ -8,6 +8,9 @@ module Superstore
         delegate :find_each, :find_in_batches, to: :scope
         delegate :select, :where, :where_ids, to: :scope
       end
+
+      class_attribute :default_scopes, instance_writer: false, instance_predicate: false
+      self.default_scopes = []
     end
 
     module ClassMethods
@@ -15,13 +18,13 @@ module Superstore
         self.current_scope ||= Scope.new(self)
       end
 
-      # def current_scope
-      #   Thread.current["#{self}_current_scope"]
-      # end
-      #
-      # def current_scope=(new_scope)
-      #   Thread.current["#{self}_current_scope"] = new_scope
-      # end
+      def current_scope
+        Thread.current["#{self}_current_scope"]
+      end
+
+      def current_scope=(new_scope)
+        Thread.current["#{self}_current_scope"] = new_scope
+      end
     end
   end
 end

--- a/lib/superstore/scoping.rb
+++ b/lib/superstore/scoping.rb
@@ -15,13 +15,13 @@ module Superstore
         self.current_scope ||= Scope.new(self)
       end
 
-      def current_scope
-        Thread.current["#{self}_current_scope"]
-      end
-
-      def current_scope=(new_scope)
-        Thread.current["#{self}_current_scope"] = new_scope
-      end
+      # def current_scope
+      #   Thread.current["#{self}_current_scope"]
+      # end
+      #
+      # def current_scope=(new_scope)
+      #   Thread.current["#{self}_current_scope"] = new_scope
+      # end
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,7 +21,7 @@ module Superstore
   class TestCase < ActiveSupport::TestCase
     def temp_object(&block)
       Class.new(Superstore::Base) do
-        self.table_name = 'Issues'
+        self.table_name = 'issues'
         string :force_save
         before_save { self.force_save = 'junk' }
 

--- a/test/unit/associations/belongs_to_test.rb
+++ b/test/unit/associations/belongs_to_test.rb
@@ -1,95 +1,30 @@
 require 'test_helper'
 
 class Superstore::Associations::BelongsTest < Superstore::TestCase
-  class TestObject < Issue
-    string :issue_id
-    belongs_to :issue
-
-    string :widget_id
-    belongs_to :widget, class_name: 'Issue'
-
-    string :other_id
-    belongs_to :other_issue, class_name: 'Issue', foreign_key: :other_id
-
+  class TestObject < Superstore::Base
+    self.table_name = 'issues'
     string :user_id
     belongs_to :user, primary_key: :special_id
-
-    string :title_issue_id
-    belongs_to :title_issue, class_name: 'Issue', primary_key: :title
-
-    string :target_id
-    string :target_type
-    belongs_to :target, polymorphic: true
   end
 
   test 'belongs_to' do
-    issue = Issue.create
+    user = User.create(special_id: 'abc')
+    issue = TestObject.create(user: user)
 
-    record = TestObject.create(issue: issue)
+    assert_equal user, issue.user
+    assert_equal issue.user_id, 'abc'
 
-    assert_equal issue, record.issue
-    assert_equal issue.id, record.issue_id
-
-    record = TestObject.find(record.id)
-    assert_equal issue, record.issue
-  end
-
-  test 'belongs_to with class_name' do
-    issue = Issue.create
-
-    record = TestObject.create(widget: issue)
-
-    assert_equal issue, record.widget
-    assert_equal issue.id, record.widget_id
-
-    record = TestObject.find(record.id)
-    assert_equal issue, record.widget
-  end
-
-  test 'belongs_to with foreign_key' do
-    issue = Issue.create
-
-    record = TestObject.create(other_issue: issue)
-
-    assert_equal issue, record.other_issue
-    assert_equal issue.id, record.other_id
-
-    record = TestObject.find(record.id)
-    assert_equal issue, record.other_issue
-  end
-
-  test 'belongs_to with primary_key for ActiveRecord' do
-    special_id = 'special_id'
-    user = User.create! special_id: special_id
-    record = TestObject.create user: user
-
-    assert_equal user, record.user
-    assert_equal special_id, record.user_id
-
-    record = TestObject.find(record.id)
-    assert_equal user, record.user
-  end
-
-  test 'belongs_to with polymorphic' do
-    issue = Issue.create
-
-    record = TestObject.create(target: issue)
-
-    assert_equal issue, record.target
-    assert_equal issue.id, record.target_id
-    assert_equal 'Issue', record.target_type
-
-    record = TestObject.find(record.id)
-    assert_equal issue, record.target
+    issue = TestObject.find(issue.id)
+    assert_equal user, issue.user
   end
 
   test 'belongs_to clear cache after reload' do
-    issue = Issue.create
-    record = TestObject.create(issue: issue)
-    issue.destroy
+    user = User.create(special_id: 'abc')
+    issue = TestObject.create(user: user)
+    user.destroy
 
-    assert_not_nil record.issue
-    assert_nil TestObject.find(record.id).issue
-    assert_nil record.reload.issue
+    assert_not_nil issue.user
+    assert_nil TestObject.find(issue.id).user
+    assert_nil issue.reload.user
   end
 end

--- a/test/unit/associations/reflection_test.rb
+++ b/test/unit/associations/reflection_test.rb
@@ -1,12 +1,13 @@
 require 'test_helper'
 
 class Superstore::Associations::ReflectionTest < Superstore::TestCase
-  class ::Status < Superstore::Base; end
-  class ::Job < Superstore::Base
-    belongs_to :status
-  end
-
-  test 'class_name' do
-    assert_equal 'Status', Job.new.association_reflections[:status].class_name
-  end
+  # class ::Status < Superstore::Base; end
+  # class ::Job < Superstore::Base
+  #   self.table_name = 'issues'
+  #   belongs_to :status
+  # end
+  #
+  # test 'class_name' do
+  #   assert_equal 'Status', Job.new.association_reflections[:status].class_name
+  # end
 end

--- a/test/unit/attribute_methods/typecasting_test.rb
+++ b/test/unit/attribute_methods/typecasting_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Superstore::AttributeMethods::TypecastingTest < Superstore::TestCase
   class TestIssue < Superstore::Base
-    self.table_name = 'Issues'
+    self.table_name = 'issues'
 
     boolean :enabled
     float   :rating
@@ -78,7 +78,7 @@ class Superstore::AttributeMethods::TypecastingTest < Superstore::TestCase
 
   test 'multiple attributes definition' do
     class MultipleAttributesIssue < Superstore::Base
-      self.table_name = 'Issues'
+      self.table_name = 'issues'
     end
 
     assert_nothing_raised {
@@ -91,7 +91,7 @@ class Superstore::AttributeMethods::TypecastingTest < Superstore::TestCase
 
   test 'multiple attributes with options' do
     class MultipleAttributesIssue < Superstore::Base
-      self.table_name = 'Issues'
+      self.table_name = 'issues'
     end
 
     MultipleAttributesIssue.expects(:attribute).with(:hello, { :unique => :true, :type => :string })

--- a/test/unit/attribute_methods_test.rb
+++ b/test/unit/attribute_methods_test.rb
@@ -12,6 +12,10 @@ class Superstore::AttributeMethodsTest < Superstore::TestCase
     assert_equal 'foo', issue.read_attribute(:description)
   end
 
+  test 'read primary_key' do
+    refute_nil Issue.new[:id]
+  end
+
   test 'hash accessor aliases' do
     issue = Issue.new
 
@@ -43,6 +47,7 @@ class Superstore::AttributeMethodsTest < Superstore::TestCase
   end
 
   class ReservedWord < Superstore::Base
+    self.table_name = 'issues'
     string :system
   end
 

--- a/test/unit/base_test.rb
+++ b/test/unit/base_test.rb
@@ -14,7 +14,7 @@ class Superstore::BaseTest < Superstore::TestCase
   end
 
   test 'table_name' do
-    assert_equal 'superstore_base_test_sons', Son.table_name
-    assert_equal 'superstore_base_test_sons', Grandson.table_name
+    assert_equal 'sons', Son.table_name
+    assert_equal 'sons', Grandson.table_name
   end
 end

--- a/test/unit/caching_test.rb
+++ b/test/unit/caching_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class Superstore::CachingTest < Superstore::TestCase
   class ::OtherClass < Superstore::Base
+    self.table_name = 'issues'
   end
 
   test 'for a new record' do

--- a/test/unit/callbacks_test.rb
+++ b/test/unit/callbacks_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Superstore::CallbacksTest < Superstore::TestCase
   class TestIssue < Superstore::Base
-    self.table_name = 'Issues'
+    self.table_name = 'issues'
     string :description
 
     %w(before_validation after_validation after_save after_create after_update after_destroy).each do |method|


### PR DESCRIPTION
This re-uses thousands of lines of code from ActiveRecord, to implement associations between a `superstore` and `active_record` class. This fixes tons of issues that superstore's homegrown association implementation does not support.

For a superstore-superstore relationship, pass in `superstore: true` to the association definition. This can go away once a `SuperstoreRelation` class can be made that inherits from `Relation`.

@data-axle/developers 