### PR TITLE
Ensure that new_record is not set until before_save callbacks complete

### DIFF
--- a/lib/superstore/persistence.rb
+++ b/lib/superstore/persistence.rb
@@ -136,7 +136,6 @@ module Superstore
     private
 
       def create_self
-        @new_record = false
         write :insert_record
       end
 
@@ -145,6 +144,7 @@ module Superstore
       end
 
       def write(method)
+        @new_record = false
         self.class.send(method, id, unapplied_changes)
       end
   end

--- a/test/unit/callbacks_test.rb
+++ b/test/unit/callbacks_test.rb
@@ -58,4 +58,26 @@ class Superstore::CallbacksTest < Superstore::TestCase
 
     assert_equal ['after_destroy'], issue.callback_history
   end
+
+  test 'new_record during callbacks' do
+    class NewRecordTestClass < Superstore::Base
+      self.table_name = 'issues'
+      string :description
+
+      before_create :expect_new_record
+      before_save   :expect_new_record
+      after_create  :refute_new_record
+      after_save    :refute_new_record
+
+      def expect_new_record
+        raise "Expected new_record? to be true!" unless new_record?
+      end
+
+      def refute_new_record
+        raise "Expected new_record? to be false!" if new_record?
+      end
+    end
+
+    NewRecordTestClass.create
+  end
 end


### PR DESCRIPTION
# Overview

Despite our best efforts to copy and paste as much code from ActiveRecord into Superstore as possible, we managed to introduce a bug where `@new_record` was being set to false _after_ the `before_create` callbacks, but _before_ the `before_save` callbacks.

This PR fixes that.

@malept 

# TODO

* [x] - Test