### PR TITLE
Ensure changed_attributes is copied when .becomes is invoked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
+# Unreleased
+
+## Fixed
+
+* Ensure `changed_attributes` is copied when `.becomes` is invoked (#21)
+
 # 2.4.1
 
 Released 2016-08-22.
 
-# Fixed
+## Fixed
 
 * Ensure that new_record is not set until before_save callbacks complete (#20)
 

--- a/lib/superstore/persistence.rb
+++ b/lib/superstore/persistence.rb
@@ -122,6 +122,7 @@ module Superstore
     def becomes(klass)
       became = klass.new
       became.instance_variable_set("@attributes", @attributes)
+      became.instance_variable_set("@changed_attributes", changed_attributes || {})
       became.instance_variable_set("@new_record", new_record?)
       became.instance_variable_set("@destroyed", destroyed?)
       became

--- a/test/unit/persistence_test.rb
+++ b/test/unit/persistence_test.rb
@@ -144,10 +144,21 @@ class Superstore::PersistenceTest < Superstore::TestCase
   end
 
   test 'becomes' do
-    klass = temp_object do
-    end
+    klass = temp_object
 
     assert_kind_of klass, Issue.new.becomes(klass)
+  end
+
+  test 'becomes includes changed_attributes' do
+    klass = temp_object do
+      string :title
+    end
+
+    issue = Issue.new(title: 'Something is wrong')
+    other = issue.becomes(klass)
+
+    assert_equal 'Something is wrong', other.title
+    assert_equal %w(title), other.changed
   end
 
   test 'reload' do


### PR DESCRIPTION
Without this change, none of the copied attributes are considered "dirty", and so there is nothing in the saved `document` in the database.

The changes are based on the equivalent ActiveRecord code:
* https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/persistence.rb#L202
* https://github.com/rails/rails/blob/abe3da9f12710ea85be69b17172bef41220037fc/activerecord/test/cases/persistence_test.rb#L193-L198

CC: @matthuhiggins @ebarendt 