### PR TITLE
Consistent DateType, TimeType decoding & typecasting

### DIFF
--- a/lib/superstore/types/date_type.rb
+++ b/lib/superstore/types/date_type.rb
@@ -15,7 +15,7 @@ module Superstore
       end
 
       def typecast(value)
-        value.to_date
+        value.to_date rescue nil
       end
     end
   end

--- a/lib/superstore/types/date_type.rb
+++ b/lib/superstore/types/date_type.rb
@@ -11,7 +11,7 @@ module Superstore
       def decode(str)
         Date.strptime(str, FORMAT) unless str.empty?
       rescue
-        Date.parse(str)
+        Date.parse(str) rescue nil
       end
 
       def typecast(value)

--- a/lib/superstore/types/time_type.rb
+++ b/lib/superstore/types/time_type.rb
@@ -30,6 +30,10 @@ module Superstore
       rescue ArgumentError
         Time.parse(str).in_time_zone rescue nil
       end
+
+      def typecast(value)
+        value.to_time.in_time_zone rescue nil
+      end
     end
   end
 end

--- a/test/unit/types/date_type_test.rb
+++ b/test/unit/types/date_type_test.rb
@@ -6,11 +6,10 @@ class Superstore::Types::DateTypeTest < Superstore::Types::TestCase
   end
 
   test 'decode' do
+    assert_nil type.decode('')
+    assert_nil type.decode('nil')
+    assert_nil type.decode('bad format')
     assert_equal Date.new(2004, 4, 25), type.decode('2004-04-25')
     assert_equal Date.new(2017, 5, 1), type.decode('2017-05-01T21:39:06.796897Z')
-  end
-
-  test 'decoding a blank dates' do
-    assert_nil type.decode('')
   end
 end

--- a/test/unit/types/date_type_test.rb
+++ b/test/unit/types/date_type_test.rb
@@ -12,4 +12,9 @@ class Superstore::Types::DateTypeTest < Superstore::Types::TestCase
     assert_equal Date.new(2004, 4, 25), type.decode('2004-04-25')
     assert_equal Date.new(2017, 5, 1), type.decode('2017-05-01T21:39:06.796897Z')
   end
+
+  test 'typecast' do
+    assert_nil type.typecast(1000)
+    assert_nil type.typecast(1000.0)
+  end
 end

--- a/test/unit/types/date_type_test.rb
+++ b/test/unit/types/date_type_test.rb
@@ -16,5 +16,8 @@ class Superstore::Types::DateTypeTest < Superstore::Types::TestCase
   test 'typecast' do
     assert_nil type.typecast(1000)
     assert_nil type.typecast(1000.0)
+
+    my_time = Time.current
+    assert_equal my_time.to_date, type.typecast(my_time)
   end
 end

--- a/test/unit/types/time_type_test.rb
+++ b/test/unit/types/time_type_test.rb
@@ -25,5 +25,8 @@ class Superstore::Types::TimeTypeTest < Superstore::Types::TestCase
   test 'typecast' do
     assert_nil type.typecast(1000)
     assert_nil type.typecast(1000.0)
+
+    my_date = Date.new
+    assert_equal my_date.to_time, type.typecast(my_date)
   end
 end

--- a/test/unit/types/time_type_test.rb
+++ b/test/unit/types/time_type_test.rb
@@ -21,4 +21,9 @@ class Superstore::Types::TimeTypeTest < Superstore::Types::TestCase
       assert_equal 'CDT', with_zone.zone
     end
   end
+
+  test 'typecast' do
+    assert_nil type.typecast(1000)
+    assert_nil type.typecast(1000.0)
+  end
 end


### PR DESCRIPTION
Instantiating a type with an invalid value should set the value to null and not throw an error.