### PR TITLE
Clarify encode/decode/typecast

### DIFF
--- a/lib/superstore/attribute_methods/definition.rb
+++ b/lib/superstore/attribute_methods/definition.rb
@@ -7,10 +7,16 @@ module Superstore
         @type = type_class.new(model, options)
       end
 
-      def instantiate(value)
-        return if value.nil?
+      def encode(value)
+        type.encode(value) unless value.nil?
+      end
 
-        value.kind_of?(String) ? type.decode(value) : type.typecast(value)
+      def decode(value)
+        type.decode(value) unless value.nil?
+      end
+
+      def typecast(value)
+        type.typecast(value) unless value.nil?
       end
     end
   end

--- a/lib/superstore/attribute_methods/typecasting.rb
+++ b/lib/superstore/attribute_methods/typecasting.rb
@@ -38,7 +38,7 @@ module Superstore
 
         def typecast_attribute(name, value)
           if attribute_definition = attribute_definitions[name.to_s]
-            attribute_definition.instantiate(value)
+            attribute_definition.typecast(value)
           else
             raise NoMethodError, "Unknown attribute #{name.inspect}"
           end

--- a/lib/superstore/persistence.rb
+++ b/lib/superstore/persistence.rb
@@ -25,7 +25,7 @@ module Superstore
           object.instance_variable_set("@new_record", false)
           object.instance_variable_set("@destroyed", false)
           document = attributes['document'].is_a?(String) ? JSON.parse(attributes['document']) : attributes['document']
-          object.instance_variable_set("@attributes", typecast_persisted_attributes(document))
+          object.instance_variable_set("@attributes", decode_persisted_attributes(document))
           object.instance_variable_set("@association_cache", {})
           object.instance_variable_set("@_start_transaction_state", {})
           object.instance_variable_set("@transaction_state", nil)
@@ -35,23 +35,19 @@ module Superstore
       def encode_attributes(attributes)
         encoded = {}
         attributes.each do |column_name, value|
-          if value.nil?
-            encoded[column_name] = nil
-          else
-            encoded[column_name] = attribute_definitions[column_name].type.encode(value)
-          end
+          encoded[column_name] = attribute_definitions[column_name].encode(value)
         end
         encoded
       end
 
       private
 
-        def typecast_persisted_attributes(attributes)
+        def decode_persisted_attributes(attributes)
           result = {}
 
           attributes.each do |key, value|
             if definition = attribute_definitions[key]
-              result[key] = definition.instantiate(value)
+              result[key] = definition.decode(value)
             end
           end
 

--- a/lib/superstore/types/array_type.rb
+++ b/lib/superstore/types/array_type.rb
@@ -2,7 +2,7 @@ module Superstore
   module Types
     class ArrayType < BaseType
       def typecast(value)
-        value.to_a
+        value.to_a rescue nil
       end
     end
   end

--- a/lib/superstore/types/array_type.rb
+++ b/lib/superstore/types/array_type.rb
@@ -1,10 +1,6 @@
 module Superstore
   module Types
     class ArrayType < BaseType
-      def decode(val)
-        val unless val.blank?
-      end
-
       def typecast(value)
         value.to_a
       end

--- a/lib/superstore/types/boolean_type.rb
+++ b/lib/superstore/types/boolean_type.rb
@@ -2,19 +2,14 @@ module Superstore
   module Types
     class BooleanType < BaseType
       TRUE_VALS = [true, 'true', '1']
-      FALSE_VALS = [false, 'false', '0', '', nil]
-      VALID_VALS = TRUE_VALS + FALSE_VALS
+      FALSE_VALS = [false, 'false', '0']
 
-      def encode(bool)
-        unless VALID_VALS.include?(bool)
-          raise ArgumentError.new("#{bool.inspect} is not a Boolean")
+      def typecast(value)
+        if TRUE_VALS.include?(value)
+          true
+        elsif FALSE_VALS.include?(value)
+          false
         end
-
-        TRUE_VALS.include?(bool)
-      end
-
-      def decode(str)
-        TRUE_VALS.include?(str)
       end
     end
   end

--- a/lib/superstore/types/date_type.rb
+++ b/lib/superstore/types/date_type.rb
@@ -8,9 +8,7 @@ module Superstore
       end
 
       def decode(str)
-        Date.strptime(str, FORMAT) unless str.empty?
-      rescue
-        Date.parse(str) rescue nil
+        Date.strptime(str, FORMAT)
       end
 
       def typecast(value)

--- a/lib/superstore/types/float_type.rb
+++ b/lib/superstore/types/float_type.rb
@@ -1,12 +1,8 @@
 module Superstore
   module Types
     class FloatType < BaseType
-      def decode(str)
-        str.to_f unless str.empty?
-      end
-
       def typecast(value)
-        value.to_f
+        value.to_f if value.present? && value.respond_to?(:to_f)
       end
     end
   end

--- a/lib/superstore/types/float_type.rb
+++ b/lib/superstore/types/float_type.rb
@@ -2,7 +2,7 @@ module Superstore
   module Types
     class FloatType < BaseType
       def typecast(value)
-        value.to_f if value.present? && value.respond_to?(:to_f)
+        Float(value) rescue nil
       end
     end
   end

--- a/lib/superstore/types/geo_point_type.rb
+++ b/lib/superstore/types/geo_point_type.rb
@@ -1,10 +1,14 @@
 module Superstore
   module Types
     class GeoPointType < BaseType
+      def decode(value)
+        {lat: value['lat'], lon: value['lon']}
+      end
+
       def typecast(value)
         case value
-        case String
-          typecast str.split(/[,\s]+/)
+        when String
+          typecast value.split(/[,\s]+/)
         when Array
           to_float_or_nil(lat: value[0], lon: value[1])
         when Hash

--- a/lib/superstore/types/geo_point_type.rb
+++ b/lib/superstore/types/geo_point_type.rb
@@ -1,12 +1,10 @@
 module Superstore
   module Types
     class GeoPointType < BaseType
-      def decode(str)
-        typecast str.split(/[,\s]+/)
-      end
-
       def typecast(value)
         case value
+        case String
+          typecast str.split(/[,\s]+/)
         when Array
           to_float_or_nil(lat: value[0], lon: value[1])
         when Hash

--- a/lib/superstore/types/integer_type.rb
+++ b/lib/superstore/types/integer_type.rb
@@ -1,12 +1,8 @@
 module Superstore
   module Types
     class IntegerType < BaseType
-      def decode(str)
-        str.to_i unless str.empty?
-      end
-
       def typecast(value)
-        value.to_i
+        value.to_i if value.present? && value.respond_to?(:to_i)
       end
     end
   end

--- a/lib/superstore/types/integer_type.rb
+++ b/lib/superstore/types/integer_type.rb
@@ -2,7 +2,7 @@ module Superstore
   module Types
     class IntegerType < BaseType
       def typecast(value)
-        value.to_i if value.present? && value.respond_to?(:to_i)
+        Integer(value) rescue nil
       end
     end
   end

--- a/lib/superstore/types/time_type.rb
+++ b/lib/superstore/types/time_type.rb
@@ -1,21 +1,3 @@
-class Time
-  def self.rfc3339(str)
-    parts = Date._rfc3339(str)
-
-    raise ArgumentError, "invalid date" if parts.empty?
-
-    Time.new(
-      parts.fetch(:year),
-      parts.fetch(:mon),
-      parts.fetch(:mday),
-      parts.fetch(:hour),
-      parts.fetch(:min),
-      parts.fetch(:sec) + parts.fetch(:sec_fraction, 0),
-      parts.fetch(:offset)
-    )
-  end
-end
-
 module Superstore
   module Types
     class TimeType < BaseType

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,10 +13,6 @@ require 'support/pg'
 require 'support/jsonb'
 require 'support/models'
 
-def MiniTest.filter_backtrace(bt)
-  bt
-end
-
 module Superstore
   class TestCase < ActiveSupport::TestCase
     def temp_object(&block)

--- a/test/unit/types/array_type_test.rb
+++ b/test/unit/types/array_type_test.rb
@@ -3,5 +3,6 @@ require 'test_helper'
 class Superstore::Types::ArrayTypeTest < Superstore::Types::TestCase
   test 'typecast' do
     assert_equal ['x', 'y'], type.typecast(['x', 'y'].to_set)
+    assert_equal nil, type.typecast('x')
   end
 end

--- a/test/unit/types/boolean_type_test.rb
+++ b/test/unit/types/boolean_type_test.rb
@@ -1,9 +1,12 @@
 require 'test_helper'
 
 class Superstore::Types::BooleanTypeTest < Superstore::Types::TestCase
-  test 'decode' do
-    assert_equal true, type.decode('1')
-    assert_equal false, type.decode('0')
-    # assert_nil type.decode(nil)
+  test 'typecast' do
+    assert_equal true, type.typecast('1')
+    assert_equal true, type.typecast('true')
+    assert_equal true, type.typecast('true')
+    assert_equal false, type.typecast('0')
+    assert_equal false, type.typecast(false)
+    assert_nil type.typecast('')
   end
 end

--- a/test/unit/types/date_type_test.rb
+++ b/test/unit/types/date_type_test.rb
@@ -6,16 +6,17 @@ class Superstore::Types::DateTypeTest < Superstore::Types::TestCase
   end
 
   test 'decode' do
-    assert_nil type.decode('')
-    assert_nil type.decode('nil')
-    assert_nil type.decode('bad format')
     assert_equal Date.new(2004, 4, 25), type.decode('2004-04-25')
-    assert_equal Date.new(2017, 5, 1), type.decode('2017-05-01T21:39:06.796897Z')
   end
 
   test 'typecast' do
     assert_nil type.typecast(1000)
     assert_nil type.typecast(1000.0)
+    assert_nil type.typecast('')
+    assert_nil type.typecast('nil')
+    assert_nil type.typecast('bad format')
+    assert_equal Date.new(2004, 4, 25), type.typecast('2004-04-25')
+    assert_equal Date.new(2017, 5, 1), type.typecast('2017-05-01T21:39:06.796897Z')
 
     my_time = Time.current
     assert_equal my_time.to_date, type.typecast(my_time)

--- a/test/unit/types/float_type_test.rb
+++ b/test/unit/types/float_type_test.rb
@@ -1,13 +1,8 @@
 require 'test_helper'
 
 class Superstore::Types::FloatTypeTest < Superstore::Types::TestCase
-  test 'decode' do
-    assert_equal 0.0, type.decode('xyz')
-    assert_equal 3.14, type.decode('3.14')
-    assert_equal 5, type.decode('5')
-  end
-
   test 'typecast' do
+    assert_nil type.decode('xyz')
     assert_equal 1.1, type.typecast('1.1')
     assert_equal 42.0, type.typecast(42)
   end

--- a/test/unit/types/float_type_test.rb
+++ b/test/unit/types/float_type_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Superstore::Types::FloatTypeTest < Superstore::Types::TestCase
   test 'typecast' do
-    assert_nil type.decode('xyz')
+    assert_nil type.typecast('xyz')
     assert_equal 1.1, type.typecast('1.1')
     assert_equal 42.0, type.typecast(42)
   end

--- a/test/unit/types/geo_point_type_test.rb
+++ b/test/unit/types/geo_point_type_test.rb
@@ -5,9 +5,7 @@ class Superstore::Types::GeoPointTypeTest < Superstore::Types::TestCase
     lat, lon = 47.604, -122.329
     seattle = {lat: lat, lon: lon}
 
-    assert_equal seattle, type.decode("#{lat}, #{lon}")
-    assert_equal seattle, type.decode("#{lat} #{lon}")
-    assert_nil type.decode('invalid')
+    assert_equal seattle, type.decode('lat' => lat, 'lon' => lon)
   end
 
   test 'typecast' do

--- a/test/unit/types/integer_type_test.rb
+++ b/test/unit/types/integer_type_test.rb
@@ -1,10 +1,10 @@
 require 'test_helper'
 
 class Superstore::Types::IntegerTypeTest < Superstore::Types::TestCase
-  test 'decode' do
-    assert_raise(ArgumentError) { type.decode('') }
-    assert_equal(0, type.decode('abc'))
-    assert_equal(3, type.decode('3'))
-    assert_equal(-3, type.decode('-3'))
+  test 'typecast' do
+    assert_nil type.typecast('')
+    assert_nil type.typecast('abc')
+    assert_equal 3, type.typecast('3')
+    assert_equal -3, type.typecast('-3')
   end
 end

--- a/test/unit/types/integer_type_test.rb
+++ b/test/unit/types/integer_type_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Superstore::Types::IntegerTypeTest < Superstore::Types::TestCase
   test 'decode' do
-    assert_nil type.decode('')
+    assert_raise(ArgumentError) { type.decode('') }
     assert_equal(0, type.decode('abc'))
     assert_equal(3, type.decode('3'))
     assert_equal(-3, type.decode('-3'))


### PR DESCRIPTION
Due to superstore's history with other key/value stores, there were some ambiguous semantics around these three methods. Their definitions:

* `encode` - Converts the ruby value to json for database storage. This is only used when JSON does not support the type, such as datetimes.
* `decode` - Converts the json value from the database to ruby. This is only used when JSON cannot represent the type, such as datetimes.
* `typecast` - Convert the user input to the model attributes. This is to support CRUD such as forms. For example, `Widget.new(price: "5.34").price => 5.34`.