### PR TITLE
Assume zero-padded numbers are not octal

### DIFF
--- a/lib/superstore/types/integer_type.rb
+++ b/lib/superstore/types/integer_type.rb
@@ -2,7 +2,12 @@ module Superstore
   module Types
     class IntegerType < BaseType
       def typecast(value)
-        Integer(value) rescue nil
+        if value.is_a?(String)
+          Integer(value, 10)
+        else
+          Integer(value)
+        end
+      rescue
       end
     end
   end

--- a/test/unit/types/integer_type_test.rb
+++ b/test/unit/types/integer_type_test.rb
@@ -4,7 +4,9 @@ class Superstore::Types::IntegerTypeTest < Superstore::Types::TestCase
   test 'typecast' do
     assert_nil type.typecast('')
     assert_nil type.typecast('abc')
+    assert_equal 3, type.typecast(3)
     assert_equal 3, type.typecast('3')
     assert_equal -3, type.typecast('-3')
+    assert_equal 27, type.typecast('027')
   end
 end


### PR DESCRIPTION
We may want to revisit this in the future, but it is what it is for now, since the change in #32 caused a regression in an app.

There's a little more logic than I would have liked because of:

```
irb(main):001:0> Integer(4, 10)
Traceback (most recent call last):
        3: from ruby-2.5.0/bin/irb:11:in `<main>'
        2: from (irb):1
        1: from (irb):1:in `Integer'
ArgumentError (base specified for non string value)
```