### PR TITLE
Hotfix time encoding

### DIFF
--- a/lib/superstore/types/time_type.rb
+++ b/lib/superstore/types/time_type.rb
@@ -4,7 +4,7 @@ module Superstore
       def encode(time)
         raise ArgumentError.new("#{time.inspect} does not respond to #to_time") unless time.is_a?(Time) || time.respond_to?(:to_time)
         time = time.to_time unless time.is_a?(Time)
-        time.utc.xmlschema(6)
+        time.utc.as_json
       end
 
       def decode(str)

--- a/test/unit/types/time_type_test.rb
+++ b/test/unit/types/time_type_test.rb
@@ -2,8 +2,8 @@ require 'test_helper'
 
 class Superstore::Types::TimeTypeTest < Superstore::Types::TestCase
   test 'encode' do
-    assert_equal '2004-12-24T01:02:03.000000Z', type.encode(Time.utc(2004, 12, 24, 1, 2, 3))
-    assert_equal '2004-12-24T01:02:03.000000Z', type.encode(DateTime.new(2004, 12, 24, 1, 2, 3))
+    assert_equal '2004-12-24T01:02:03.000Z', type.encode(Time.utc(2004, 12, 24, 1, 2, 3))
+    assert_equal '2004-12-24T01:02:03.000Z', type.encode(DateTime.new(2004, 12, 24, 1, 2, 3))
     assert_raise ArgumentError do
       type.encode 123
     end


### PR DESCRIPTION
This serialization behavior doesn't seem necessary. More-so, causes some problems.

Would like input if anyone sees potential issues with this change. Seems like it shouldn't be a problem...I don't think we need 6 decimals of sub-second precision anyway.