### PR TITLE
RangeType decode more flexible

### DIFF
--- a/lib/superstore/types/range_type.rb
+++ b/lib/superstore/types/range_type.rb
@@ -11,8 +11,12 @@ module Superstore
       end
 
       def decode(range_tuple)
-        range = convert_min(:decode, range_tuple[0]) .. convert_max(:decode, range_tuple[1])
-        typecast(range)
+        if range_tuple.is_a? Range
+          range_tuple
+        else
+          range = convert_min(:decode, range_tuple[0]) .. convert_max(:decode, range_tuple[1])
+          typecast(range)
+        end
       end
 
 

--- a/test/unit/types/date_range_type_test.rb
+++ b/test/unit/types/date_range_type_test.rb
@@ -8,6 +8,10 @@ class Superstore::Types::DateRangeTypeTest < Superstore::Types::TestCase
   test 'decode' do
     assert_equal Date.new(2004, 4, 25)..Date.new(2004, 5, 15), type.decode(["2004-04-25", "2004-05-15"])
     assert_nil type.decode(["2004-05-15", "2004-04-25"])
+
+    # decode returns argument if already a Range
+    range = Date.new(2019, 1, 1)..Date.new(2019, 2, 1)
+    assert_equal range, type.decode(range)
   end
 
   test 'typecast' do


### PR DESCRIPTION
### Explanation

Since `RangeType#decode` is a public method, users can try using it to decode any kind of value -- there's no guarantee that the value was just pulled from the JSONB document. This change makes the `decode` method a little more flexible in that it wont try to decode the parameter if it is already in a Range form.

### Changes

* Adds check to `RangeType#decode` that returns the value passed if it's already a `Range` object.

### Notes

Related to https://github.com/data-axle/elastic_record/pull/93