### PR TITLE
Fix Memory Regression - Freeze default primary_key string

### DIFF
--- a/lib/superstore/attribute_methods/primary_key.rb
+++ b/lib/superstore/attribute_methods/primary_key.rb
@@ -11,9 +11,8 @@ module Superstore
       end
 
       module ClassOverrides
-        PRIMARY_KEY = 'id'
         def primary_key
-          PRIMARY_KEY
+          'id'.freeze
         end
       end
 

--- a/lib/superstore/attribute_methods/primary_key.rb
+++ b/lib/superstore/attribute_methods/primary_key.rb
@@ -11,8 +11,9 @@ module Superstore
       end
 
       module ClassOverrides
+        PRIMARY_KEY = 'id'
         def primary_key
-          'id'
+          PRIMARY_KEY
         end
       end
 


### PR DESCRIPTION
**Problem**
Every call to `Widget.primary_key` initializes a new string. This is a problem given that `primary_key` is called repeatedly by `ActiveRecord` and `Superstore`.

When I call `Widget.primary_key.object_id` I expect the `object_id` to be the same for every call.

```ruby
> Widget.primary_key.object_id
=> 70251662713500
> Widget.primary_key.object_id
=> 70251662979920
```

**Solution**
Freeze the default primary key string