### PR TITLE
Drop methods such as string(attribute_name)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,9 @@ Superstore will share the existing ActiveRecord database connection.
 
 ```ruby
 class Widget < Superstore::Base
-  string :name
-  string :description
-  integer :price
-  array :colors, unique: true
+  attribute :name, type: :string
+  attribute :price, type: :integer
+  attribute :colors, type: :array
 
   validates :name, presence: :true
 

--- a/lib/superstore/attributes.rb
+++ b/lib/superstore/attributes.rb
@@ -5,17 +5,6 @@ module Superstore
     included do
       include ActiveRecord::Attributes
       extend ClassOverrides
-
-      %w(array boolean date date_range float integer integer_range json string time).each do |type|
-        instance_eval <<-EOV, __FILE__, __LINE__ + 1
-          def #{type}(*args)
-            options = args.extract_options!
-            args.each do |name|
-              attribute(name, options.merge(:type => :#{type}))
-            end
-          end
-        EOV
-      end
     end
 
     module ClassOverrides

--- a/lib/superstore/model_schema.rb
+++ b/lib/superstore/model_schema.rb
@@ -9,7 +9,7 @@ module Superstore
 
     module ClassOverrides
       def attributes_builder # :nodoc:
-        @attributes_builder ||= ActiveModel::AttributeSet.new(attribute_types, _default_attributes)
+        @attributes_builder ||= ActiveModel::AttributeSet::Builder.new(attribute_types, _default_attributes)
       end
 
       def table_exists?

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -6,10 +6,10 @@ class Label < ActiveRecord::Base
 end
 
 class Issue < Superstore::Base
-  string :description
-  string :title
-  string :parent_issue_id
-  json :comments
+  attribute :description, type: :string
+  attribute :title, type: :string
+  attribute :parent_issue_id, type: :string
+  attribute :comments, type: :json
 
   before_create { self.description ||= 'funny' }
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,7 +22,7 @@ module Superstore
     def temp_object(&block)
       Class.new(Superstore::Base) do
         self.table_name = 'issues'
-        string :force_save
+        attribute :force_save, type: :string
         before_save { self.force_save = 'junk' }
 
         def self.name

--- a/test/unit/associations/belongs_to_test.rb
+++ b/test/unit/associations/belongs_to_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class Superstore::Associations::BelongsTest < Superstore::TestCase
   class TestObject < Superstore::Base
     self.table_name = 'issues'
-    string :user_id
+    attribute :user_id, type: :string
     belongs_to :user, primary_key: :special_id
   end
 

--- a/test/unit/attribute_methods/dirty_test.rb
+++ b/test/unit/attribute_methods/dirty_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class Superstore::AttributeMethods::DirtyTest < Superstore::TestCase
   test 'save clears dirty' do
     record = temp_object do
-      string :name
+      attribute :name, type: :string
     end.new name: 'foo'
 
     assert record.changed?
@@ -16,7 +16,7 @@ class Superstore::AttributeMethods::DirtyTest < Superstore::TestCase
 
   test 'reload clears dirty' do
     record = temp_object do
-      string :name
+      attribute :name, type: :string
     end.create! name: 'foo'
 
     record.name = 'bar'
@@ -29,7 +29,7 @@ class Superstore::AttributeMethods::DirtyTest < Superstore::TestCase
 
   test 'cast_value float before dirty check' do
     record = temp_object do
-      float :price
+      attribute :price, type: :float
     end.create(price: 5.01)
 
     record.price = '5.01'
@@ -41,7 +41,7 @@ class Superstore::AttributeMethods::DirtyTest < Superstore::TestCase
 
   test 'cast_value boolean before dirty check' do
     record = temp_object do
-      boolean :awesome
+      attribute :awesome, type: :boolean
     end.create(awesome: false)
 
     record.awesome = false
@@ -53,7 +53,7 @@ class Superstore::AttributeMethods::DirtyTest < Superstore::TestCase
 
   test 'write_attribute' do
     object = temp_object do
-      string :name
+      attribute :name, type: :string
     end
 
     expected = {"name"=>[nil, "foo"]}
@@ -72,7 +72,7 @@ class Superstore::AttributeMethods::DirtyTest < Superstore::TestCase
 
   test 'dirty and restore to original value' do
     object = temp_object do
-      string :name
+      attribute :name, type: :string
     end
 
     record = object.create(name: 'foo')

--- a/test/unit/attribute_methods_test.rb
+++ b/test/unit/attribute_methods_test.rb
@@ -31,7 +31,7 @@ class Superstore::AttributeMethodsTest < Superstore::TestCase
   end
 
   class ModelWithOverride < Superstore::Base
-    string :title
+    attribute :title, type: :string
 
     def title=(v)
       super "#{v} lol"
@@ -45,7 +45,7 @@ class Superstore::AttributeMethodsTest < Superstore::TestCase
   end
 
   class ReservedWord < Superstore::Base
-    string :system
+    attribute :system, type: :string
   end
 
   test 'reserved words' do

--- a/test/unit/attributes_test.rb
+++ b/test/unit/attributes_test.rb
@@ -4,16 +4,16 @@ class Superstore::AttributesTest < Superstore::TestCase
   class TestIssue < Superstore::Base
     self.table_name = 'issues'
 
-    boolean :enabled
-    float   :rating
-    integer :price
-    json    :orders
-    string  :name
-    integer_range :age_range
+    attribute :enabled, type: :boolean
+    attribute :rating, type: :float
+    attribute :price, type: :integer
+    attribute :orders, type: :json
+    attribute :name, type: :string
+    attribute :age_range, type: :integer_range
   end
 
   class TestChildIssue < TestIssue
-    string :description
+    attribute :description, type: :string
   end
 
   test 'attributes not shared' do
@@ -74,31 +74,5 @@ class Superstore::AttributesTest < Superstore::TestCase
 
     issue = TestIssue.find issue.id
     assert_equal 70..Float::INFINITY, issue.age_range
-  end
-
-  test 'multiple attributes definition' do
-    class MultipleAttributesIssue < Superstore::Base
-      self.table_name = 'issues'
-    end
-
-    assert_nothing_raised {
-      MultipleAttributesIssue.string :hello, :greetings, :bye
-    }
-    issue = MultipleAttributesIssue.new :hello => 'hey', :greetings => 'how r u', :bye => 'see ya'
-
-    assert_equal 'how r u', issue.greetings
-  end
-
-  test 'multiple attributes with options' do
-    class MultipleAttributesIssue < Superstore::Base
-      self.table_name = 'issues'
-    end
-
-    MultipleAttributesIssue.expects(:attribute).with(:hello, { :unique => :true, :type => :string })
-    MultipleAttributesIssue.expects(:attribute).with(:world, { :unique => :true, :type => :string })
-
-    class MultipleAttributesIssue < Superstore::Base
-      string :hello, :world, :unique => :true
-    end
   end
 end

--- a/test/unit/callbacks_test.rb
+++ b/test/unit/callbacks_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class Superstore::CallbacksTest < Superstore::TestCase
   class TestIssue < Superstore::Base
     self.table_name = 'issues'
-    string :description
+    attribute :description, type: :string
 
     %w(
       before_validation
@@ -62,7 +62,7 @@ class Superstore::CallbacksTest < Superstore::TestCase
   test 'new_record during callbacks' do
     class NewRecordTestClass < Superstore::Base
       self.table_name = 'issues'
-      string :description
+      attribute :description, type: :string
 
       before_create :expect_new_record
       before_save   :expect_new_record

--- a/test/unit/persistence_test.rb
+++ b/test/unit/persistence_test.rb
@@ -42,7 +42,7 @@ class Superstore::PersistenceTest < Superstore::TestCase
 
   test 'save!' do
     klass = temp_object do
-      string :description
+      attribute :description, type: :string
       validates :description, presence: true
     end
 
@@ -112,7 +112,7 @@ class Superstore::PersistenceTest < Superstore::TestCase
 
   test 'becomes includes changed_attributes' do
     klass = temp_object do
-      string :title
+      attribute :title, type: :string
     end
 
     issue = Issue.new(title: 'Something is wrong')
@@ -134,7 +134,7 @@ class Superstore::PersistenceTest < Superstore::TestCase
 
   test 'delete' do
     klass = temp_object do
-      string :name
+      attribute :name, type: :string
     end
 
     record = klass.new(name: 'cool')
@@ -152,7 +152,7 @@ class Superstore::PersistenceTest < Superstore::TestCase
 
   test 'delete multiple' do
     klass = temp_object do
-      string :name
+      attribute :name, type: :string
     end
 
     ids = []


### PR DESCRIPTION
Rely on `attribute(attribute_name, type: :string)`. Makes superstore more similar to activerecord