### PR TITLE
Support boundless ranges.

### DIFF
--- a/lib/superstore/types/integer_range_type.rb
+++ b/lib/superstore/types/integer_range_type.rb
@@ -4,15 +4,11 @@ module Superstore
       self.subtype = IntegerType.new
 
       def serialize_for_open_ended(value)
-        value.abs == Float::INFINITY ? nil : super
+        value&.abs == Float::INFINITY ? nil : super
       end
 
       def convert_min(method, value)
         value.nil? ? -Float::INFINITY : super
-      end
-
-      def convert_max(method, value)
-        value.nil? ? Float::INFINITY : super
       end
     end
   end

--- a/lib/superstore/types/range_type.rb
+++ b/lib/superstore/types/range_type.rb
@@ -22,12 +22,12 @@ module Superstore
       end
 
       def cast_value(value)
-        if value.is_a?(Range) && value.begin <= value.end
+        if value.is_a?(Range) && (value.end.nil? || value.begin <= value.end)
           value
         elsif value.is_a?(Array) && value.size == 2
           begin
-            array = convert_min(:cast_value, value[0])..convert_max(:cast_value, value[1])
-            cast_value(array)
+            range = convert_min(:cast_value, value[0])..convert_max(:cast_value, value[1])
+            cast_value(range)
           rescue ArgumentError
           end
         end

--- a/test/unit/attributes_test.rb
+++ b/test/unit/attributes_test.rb
@@ -70,9 +70,9 @@ class Superstore::AttributesTest < Superstore::TestCase
 
   test 'integer_range' do
     issue = TestIssue.create! age_range: ['70', nil]
-    assert_equal 70..Float::INFINITY, issue.age_range
+    assert_equal 70.., issue.age_range
 
     issue = TestIssue.find issue.id
-    assert_equal 70..Float::INFINITY, issue.age_range
+    assert_equal 70.., issue.age_range
   end
 end

--- a/test/unit/types/date_range_type_test.rb
+++ b/test/unit/types/date_range_type_test.rb
@@ -16,13 +16,13 @@ class Superstore::Types::DateRangeTypeTest < Superstore::Types::TestCase
 
   test 'cast_value' do
     assert_equal Date.new(2004, 4, 25)..Date.new(2004, 5, 15), type.cast_value(Date.new(2004, 4, 25)..Date.new(2004, 5, 15))
-    assert_nil type.cast_value(Date.new(2004, 5, 15)..Date.new(2004, 4, 25))
     assert_equal Date.new(2004, 4, 25)..Date.new(2004, 5, 15), type.cast_value([Date.new(2004, 4, 25), Date.new(2004, 5, 15)])
-    assert_nil type.cast_value([Date.new(2004, 5, 15), Date.new(2004, 4, 25)])
     assert_equal Date.new(2004, 4, 25)..Date.new(2004, 5, 15), type.cast_value(["2004-04-25", "2004-05-15"])
     assert_equal Date.new(2004, 4, 25)..Date.new(2004, 4, 25), type.cast_value(["2004-04-25", "2004-04-25"])
+    assert_equal Date.new(2004, 4, 25)..,                      type.cast_value(["2004-04-25", nil])
 
-    assert_nil type.cast_value(["2004-04-25", nil])
+    assert_nil type.cast_value( Date.new(2004, 5, 15)..Date.new(2004, 4, 25))
+    assert_nil type.cast_value([Date.new(2004, 5, 15), Date.new(2004, 4, 25)])
     assert_nil type.cast_value([nil, "2004-05-15"])
     assert_nil type.cast_value(["xx", "2004-05-15"])
   end

--- a/test/unit/types/integer_range_type_test.rb
+++ b/test/unit/types/integer_range_type_test.rb
@@ -3,17 +3,17 @@ require 'test_helper'
 class Superstore::Types::IntegerRangeTypeTest < Superstore::Types::TestCase
   test 'serialize' do
     assert_equal [4, 5], type.serialize(4..5)
-    assert_equal [4, nil], type.serialize(4..Float::INFINITY)
+    assert_equal [4, nil], type.serialize(4..)
     assert_equal [nil, 5], type.serialize(-Float::INFINITY..5)
-    assert_equal [nil, nil], type.serialize(-Float::INFINITY..Float::INFINITY)
+    assert_equal [nil, nil], type.serialize(-Float::INFINITY..)
   end
 
   test 'deserialize' do
     assert_equal 4..5, type.deserialize([4, 5])
     assert_nil type.deserialize([5, 4])
-    assert_equal 4..Float::INFINITY, type.deserialize([4, nil])
+    assert_equal 4.., type.deserialize([4, nil])
     assert_equal (-Float::INFINITY..5), type.deserialize([nil, 5])
-    assert_equal (-Float::INFINITY..Float::INFINITY), type.deserialize([nil, nil])
+    assert_equal (-Float::INFINITY..), type.deserialize([nil, nil])
   end
 
   test 'cast_value' do
@@ -21,8 +21,8 @@ class Superstore::Types::IntegerRangeTypeTest < Superstore::Types::TestCase
     assert_nil type.cast_value(5..1)
     assert_equal 1..5, type.cast_value([1, 5])
     assert_nil type.cast_value([5, 1])
-    assert_equal 1..Float::INFINITY, type.cast_value([1, nil])
+    assert_equal 1.., type.cast_value([1, nil])
     assert_equal (-Float::INFINITY..2), type.cast_value([nil, 2])
-    assert_equal (-Float::INFINITY..Float::INFINITY), type.cast_value([nil, nil])
+    assert_equal (-Float::INFINITY..), type.cast_value([nil, nil])
   end
 end


### PR DESCRIPTION
[Basecamp TODO](https://3.basecamp.com/4119850/buckets/9653296/todos/2289514243)

Part of [Use Ruby 2.6's boundless ranges](https://3.basecamp.com/4119850/buckets/9653296/todolists/2289514940)

### Problem

Superstore is currently outputting ranges with Float::INFINITY upper bounds. We want to use boundless ranges instead.

### Status

Don't merge this until the rest of the TODO list is also ready.