### PR TITLE
Fixes for Ruby 2.7

### DIFF
--- a/lib/superstore/associations.rb
+++ b/lib/superstore/associations.rb
@@ -20,25 +20,25 @@ module Superstore
       #   end
       def belongs_to(name, options = {})
         if options.delete(:superstore)
-          Superstore::Associations::Builder::BelongsTo.build(self, name, options)
+          Superstore::Associations::Builder::BelongsTo.build(self, name, **options)
         else
-          super
+          super(name, **options)
         end
       end
 
       def has_many(name, options = {})
         if options.delete(:superstore)
-          Superstore::Associations::Builder::HasMany.build(self, name, options)
+          Superstore::Associations::Builder::HasMany.build(self, name, **options)
         else
-          super
+          super(name, **options)
         end
       end
 
       def has_one(name, options = {})
         if options.delete(:superstore)
-          Superstore::Associations::Builder::HasOne.build(self, name, options)
+          Superstore::Associations::Builder::HasOne.build(self, name, **options)
         else
-          super
+          super(name, **options)
         end
       end
 

--- a/lib/superstore/associations.rb
+++ b/lib/superstore/associations.rb
@@ -18,27 +18,27 @@ module Superstore
       #   end
       #   class Truck < Superstore::Base
       #   end
-      def belongs_to(name, options = {})
+      def belongs_to(name, **options)
         if options.delete(:superstore)
-          Superstore::Associations::Builder::BelongsTo.build(self, name, **options)
+          Superstore::Associations::Builder::BelongsTo.build(self, name, options)
         else
-          super(name, **options)
+          super
         end
       end
 
-      def has_many(name, options = {})
+      def has_many(name, **options)
         if options.delete(:superstore)
-          Superstore::Associations::Builder::HasMany.build(self, name, **options)
+          Superstore::Associations::Builder::HasMany.build(self, name, options)
         else
-          super(name, **options)
+          super
         end
       end
 
-      def has_one(name, options = {})
+      def has_one(name, **options)
         if options.delete(:superstore)
-          Superstore::Associations::Builder::HasOne.build(self, name, **options)
+          Superstore::Associations::Builder::HasOne.build(self, name, options)
         else
-          super(name, **options)
+          super
         end
       end
 

--- a/lib/superstore/associations/builder/association.rb
+++ b/lib/superstore/associations/builder/association.rb
@@ -1,11 +1,11 @@
 module Superstore::Associations::Builder
   class Association
-    def self.build(model, name, options)
-      new(model, name, options).build
+    def self.build(model, name, **options)
+      new(model, name, **options).build
     end
 
     attr_reader :model, :name, :options
-    def initialize(model, name, options)
+    def initialize(model, name, **options)
       @model, @name, @options = model, name, options
     end
 

--- a/lib/superstore/associations/builder/association.rb
+++ b/lib/superstore/associations/builder/association.rb
@@ -1,11 +1,11 @@
 module Superstore::Associations::Builder
   class Association
-    def self.build(model, name, **options)
-      new(model, name, **options).build
+    def self.build(model, name, options)
+      new(model, name, options).build
     end
 
     attr_reader :model, :name, :options
-    def initialize(model, name, **options)
+    def initialize(model, name, options)
       @model, @name, @options = model, name, options
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,10 +13,6 @@ require 'support/pg'
 require 'support/jsonb'
 require 'support/models'
 
-def MiniTest.filter_backtrace(bt)
-  bt
-end
-
 module Superstore
   class TestCase < ActiveSupport::TestCase
     def temp_object(&block)


### PR DESCRIPTION
# Problem
With the bump to Ruby 2.7, we have to handle for some coming deprecations in Ruby 3, like the separation of positional and keyword hash params - https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/.

# Solution
Switching to use the double splat operator on the caller/callee of a method fixes this deprecation warning and prepares us to upgrade to Ruby 2.7. 