### PR TITLE
Fix loading child STI instances

### DIFF
--- a/lib/superstore/persistence.rb
+++ b/lib/superstore/persistence.rb
@@ -36,6 +36,10 @@ module Superstore
           end
           attributes.each_key { |k, v| attributes.delete(k) unless attribute_types.key?(k) }
 
+          if attributes[inheritance_column]
+            klass = find_sti_class(attributes[inheritance_column])
+          end
+
           super(klass, attributes, column_types, &block)
         end
 

--- a/lib/superstore/persistence.rb
+++ b/lib/superstore/persistence.rb
@@ -36,7 +36,7 @@ module Superstore
           end
           attributes.each_key { |k, v| attributes.delete(k) unless attribute_types.key?(k) }
 
-          if attributes[inheritance_column]
+          if inheritance_column && attribute_types.key?(inheritance_column)
             klass = find_sti_class(attributes[inheritance_column])
           end
 

--- a/test/unit/persistence_test.rb
+++ b/test/unit/persistence_test.rb
@@ -4,11 +4,29 @@
 require 'test_helper'
 
 class Superstore::PersistenceTest < Superstore::TestCase
+  class Parent < Superstore::Base
+    self.inheritance_column = 'document_type'
+    attribute :document_type, type: :string
+
+    def self.find_sti_class(type)
+      Child
+    end
+  end
+
+  class Child < Parent
+  end
+
   test 'instantiate with unknowns' do
     issue = Issue.instantiate('id' => 'theid', 'document' => {'z' => 'nooo', 'title' => 'Krazy'}.to_json)
 
     refute issue.attributes.key?('z')
     assert_equal 'Krazy', issue.attributes['title']
+  end
+
+  test 'instantiate with an inheritance column' do
+    child = Parent.instantiate('id' => 'theid', 'document' => {'document_type' => 'child'}.to_json)
+
+    assert_kind_of Child, child
   end
 
   test 'persistence inquiries' do

--- a/test/unit/persistence_test.rb
+++ b/test/unit/persistence_test.rb
@@ -29,6 +29,12 @@ class Superstore::PersistenceTest < Superstore::TestCase
     assert_kind_of Child, child
   end
 
+  test 'instantiate when an inheritance column is expected but is nil' do
+    child = Parent.instantiate('id' => 'theid', 'document' => { }.to_json)
+
+    assert_kind_of Child, child
+  end
+
   test 'persistence inquiries' do
     issue = Issue.new
     assert issue.new_record?


### PR DESCRIPTION
**Problem:**

Loading child objects via the parent class name doesn't produce child objects.

**Solution:**

https://github.com/rails/rails/blob/83dd0d53d6a3e8e4fe8f06d148197007c09100fe/activerecord/lib/active_record/querying.rb#L57-L62

ActiveRecord doesn't provide a hook to change the behavior on L57, so we'll change our own `instantiate_instance_of` method to change the `klass` being instantiated.

This creates an instance of the correct child class when instantiating a record with an `inheritance_column`. It hooks into the regular `find_sti_class` AR method.