### PR TITLE
Show attribute types when inspecting superstore classes

### DIFF
--- a/lib/superstore.rb
+++ b/lib/superstore.rb
@@ -62,6 +62,7 @@ module Superstore
   module Types
     extend ActiveSupport::Autoload
 
+    autoload :Base
     autoload :ArrayType
     autoload :BooleanType
     autoload :DateType

--- a/lib/superstore/types/array_type.rb
+++ b/lib/superstore/types/array_type.rb
@@ -1,6 +1,6 @@
 module Superstore
   module Types
-    class ArrayType < ActiveModel::Type::Value
+    class ArrayType < Base
       def cast_value(value)
         Array(value)
       end

--- a/lib/superstore/types/base.rb
+++ b/lib/superstore/types/base.rb
@@ -1,0 +1,9 @@
+module Superstore
+  module Types
+    class Base < ActiveModel::Type::Value
+      def type
+        self.class.name.demodulize.sub(/Type$/, '').downcase
+      end
+    end
+  end
+end

--- a/lib/superstore/types/boolean_type.rb
+++ b/lib/superstore/types/boolean_type.rb
@@ -1,6 +1,6 @@
 module Superstore
   module Types
-    class BooleanType < ActiveModel::Type::Value
+    class BooleanType < Base
       TRUE_VALS = [true, 'true', '1']
       FALSE_VALS = [false, 'false', '0']
 

--- a/lib/superstore/types/date_type.rb
+++ b/lib/superstore/types/date_type.rb
@@ -1,6 +1,6 @@
 module Superstore
   module Types
-    class DateType < ActiveModel::Type::Value
+    class DateType < Base
       FORMAT = '%Y-%m-%d'
 
       def serialize(value)

--- a/lib/superstore/types/float_type.rb
+++ b/lib/superstore/types/float_type.rb
@@ -1,6 +1,6 @@
 module Superstore
   module Types
-    class FloatType < ActiveModel::Type::Value
+    class FloatType < Base
       def cast_value(value)
         Float(value) rescue nil
       end

--- a/lib/superstore/types/geo_point_type.rb
+++ b/lib/superstore/types/geo_point_type.rb
@@ -2,7 +2,7 @@
 
 module Superstore
   module Types
-    class GeoPointType < ActiveModel::Type::Value
+    class GeoPointType < Base
       def deserialize(value)
         {lat: value[:lat] || value['lat'], lon: value[:lon] || value['lon']} if value
       end

--- a/lib/superstore/types/integer_type.rb
+++ b/lib/superstore/types/integer_type.rb
@@ -1,6 +1,6 @@
 module Superstore
   module Types
-    class IntegerType < ActiveModel::Type::Value
+    class IntegerType < Base
       def cast_value(value)
         if value.is_a?(String)
           Integer(value, 10)

--- a/lib/superstore/types/json_type.rb
+++ b/lib/superstore/types/json_type.rb
@@ -1,6 +1,6 @@
 module Superstore
   module Types
-    class JsonType < ActiveModel::Type::Value
+    class JsonType < Base
     end
   end
 end

--- a/lib/superstore/types/range_type.rb
+++ b/lib/superstore/types/range_type.rb
@@ -1,6 +1,6 @@
 module Superstore
   module Types
-    class RangeType < ActiveModel::Type::Value
+    class RangeType < Base
       class_attribute :subtype
 
       def serialize(range)

--- a/lib/superstore/types/string_type.rb
+++ b/lib/superstore/types/string_type.rb
@@ -1,6 +1,6 @@
 module Superstore
   module Types
-    class StringType < ActiveModel::Type::Value
+    class StringType < Base
       def serialize(str)
         return if str.nil?
 

--- a/lib/superstore/types/time_type.rb
+++ b/lib/superstore/types/time_type.rb
@@ -1,6 +1,6 @@
 module Superstore
   module Types
-    class TimeType < ActiveModel::Type::Value
+    class TimeType < Base
       def serialize(time)
         time.utc.xmlschema(6) if time
       end

--- a/test/unit/core_test.rb
+++ b/test/unit/core_test.rb
@@ -42,4 +42,9 @@ class Superstore::CoreTest < Superstore::TestCase
     issue = Issue.create
     assert issue.inspect =~ /^#<Issue id: \"\w+\", description: \".+\", created_at: \".+\", updated_at: \".+\">$/
   end
+
+  test 'inspect class' do
+    expected = "Issue(id: string, description: string, title: string, parent_issue_id: string, comments: json, created_at: time, updated_at: time)"
+    assert_equal expected, Issue.inspect
+  end
 end


### PR DESCRIPTION
Issue:
Inspecting superstore classes doesn't show the types of the fields like ActiveRecord classes do. This is because the superstore types return nil from [#type](https://github.com/rails/rails/blob/master/activemodel/lib/active_model/type/value.rb#L22) which gets used in [active record](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/core.rb#L277) when inspecting the class.

Before
```
AuditLog.inspect
=> "AuditLog(id: integer, user_id: integer, target_id: string, target_type: string, text: string, created_at: datetime, updated_at: datetime, action: string)"

Place.inspect
=> "Place(id: , created_at: , updated_at: , segment_id: , accepting_new_patients: , additional_phone: , address_changed_on: , address_type_code: , affiliation_ids: , affiliation_ids_count: , alternative_name: , ami_board_certified_flag: , ami_hospital_number: , ami_license_number: , ami_medical_school_code: , ami_national_provider_flag: , ami_physician_primary_specialty_code: , ami_physician_secondary_specialty_code: , ami_residency_hospital_code: , ami_state_of_license: , ancestor_headquarters_ids: , ancestor_headquarters_ids_count: , bbb_accredited: , bbb_business_review_url: , brand_ids: , brand_ids_count: , branch_count: , branch_type_id: , building_number: , bulk_updated_at: , business_type_ids: , business_type_ids_count: , car_make_ids: , car_make_ids_count: , carrier_route_code: , cbsa_code: , cbsa_level: , census_block: , census_tract: , chain_id: , cik: , city: , cmra_flag: , company_description: , corporate_employee_count: , estimated_corporate_employee_count: , corporate_franchising: , corporate_sales_revenue: , estimated_corporate_sales_revenue: , ds_estimated_corporate_sales_revenue: , country_code: , county_code: , cross_street_address: , csa_code: , cuisines: , cuisines_count: , delivery_point_bar_code: , dress_code: , duplicate_of: , eins: , eins_count: , equipment_rentals: , estimated_fleet_size: , estimated_location_employee_count: , estimated_opened_for_business: , express_updated_at: , facebook_url: , fax_number: , federal_government_contractor: , fips_code: , fiscal_year_end_month: , foreign_parent_flag: , fortune_ranking: , foursquare_url: , geocoordinate: , geo_match_level: , greenscore: , growing_business_code: , has_ecommerce: , headquarters_id: , historical_names: , historical_names_count: , hospital_has_emergency_room: , in_business: , in_business_on: , infogroup_id: , instagram_url: , insurances_accepted: , insurances_accepted_count: , landmark_address: , languages_spoken: , languages_spoken_count: , latitude: , legal_name: , legal_names: , legal_names_count: , linked_in_url: , location_email_address: , location_employee_count: , location_parent_id: , location_parent_relationship: , location_professional_size_code: , location_sales_volume: , logo_url: , longitude: , mailing_address: , mailing_address_carrier_route_code: , mailing_address_city: , mailing_address_cmra_flag: , mailing_address_delivery_point_bar_code: , mailing_address_postal_code: , mailing_address_score_code: , mailing_address_state: , mailing_address_type_code: , mailing_address_zip: , mailing_address_zip_four: , mailing_score_code: , manual_geocoordinate: , medicaid_accepted: , medical_dea_number: , medicare_accepted: , naics_code_ids: , naics_code_ids_count: , name: , nbrc_corporate_date: , nbrc_corporation_filing_type: , number_of_tenants: , opened_for_business_on: , operating_hours_description: , operating_status: , out_of_business_on: , ownership_changed_on: , payment_types: , payment_types_count: , phone: , phone_call_status_code: , physician_year_of_birth: , physician_year_of_graduation: , pinterest_url: , place_type: , population_code_for_zip: , population_density: , postal_code: , price_range: , primary_naics_code_id: , primary_sic_code_id: , professional_specialty_ids: , professional_specialty_ids_count: , public_access: , record_list_ids: , record_list_ids_count: , religious_denomination_ids: , religious_denomination_ids_count: , reopen_date: , residency_graduation_year: , restaurant_service_type_code: , seeded_organization_id: , sgc_division: , shopping_center_atm: , sic_code_ids: , sic_code_ids_count: , single_platform_url: , square_footage: , state: , status: , stock_exchange_code: , stock_ticker_symbol: , street: , suite: , suppressed: , suppressed_fields: , suppressed_fields_count: , teleresearch_update_date: , temporarily_closed: , temporarily_closed_on: , territory: , toll_free_number: , tumblr_url: , twitter_url: , ultimate_headquarters_id: , upin: , verification_status: , verified_on: , wealthy_area_flag: , website: , website_keywords: , website_keywords_count: , website_status: , white_collar_percentage: , work_at_home: , yelp_url: , youtube_url: , zip: , zip_four: , benefit_plans: , benefit_plans_count: , contacts: , contacts_count: , happy_hours: , happy_hours_count: , images: , images_count: , in_business_reasons: , in_business_reasons_count: , location_intents: , location_intents_count: , operating_hours: , operating_hours_count: , ucc_filings: , ucc_filings_count: , tags: , tags_count: , bankruptcy: , credit: , hotel: , expenses: , limited_operations: , parking: , primary_contact: , restaurant: , service_area: )"
```

After:
```
AuditLog.inspect
=> "AuditLog(id: integer, user_id: integer, target_id: string, target_type: string, text: string, created_at: datetime, updated_at: datetime, action: string)"

Place.inspect
=> "Place(id: string, created_at: time, updated_at: time, segment_id: integer, accepting_new_patients: boolean, additional_phone: string, address_changed_on: date, address_type_code: string, affiliation_ids: array, affiliation_ids_count: integer, alternative_name: string, ami_board_certified_flag: boolean, ami_hospital_number: string, ami_license_number: string, ami_medical_school_code: string, ami_national_provider_flag: string, ami_physician_primary_specialty_code: integer, ami_physician_secondary_specialty_code: integer, ami_residency_hospital_code: string, ami_state_of_license: string, ancestor_headquarters_ids: array, ancestor_headquarters_ids_count: integer, bbb_accredited: boolean, bbb_business_review_url: string, brand_ids: array, brand_ids_count: integer, branch_count: integer, branch_type_id: integer, building_number: string, bulk_updated_at: time, business_type_ids: array, business_type_ids_count: integer, car_make_ids: array, car_make_ids_count: integer, carrier_route_code: string, cbsa_code: string, cbsa_level: string, census_block: string, census_tract: string, chain_id: string, cik: string, city: string, cmra_flag: boolean, company_description: string, corporate_employee_count: integer, estimated_corporate_employee_count: integer, corporate_franchising: boolean, corporate_sales_revenue: integer, estimated_corporate_sales_revenue: integer, ds_estimated_corporate_sales_revenue: integer, country_code: string, county_code: string, cross_street_address: string, csa_code: string, cuisines: array, cuisines_count: integer, delivery_point_bar_code: string, dress_code: string, duplicate_of: string, eins: array, eins_count: integer, equipment_rentals: boolean, estimated_fleet_size: integerrange, estimated_location_employee_count: integer, estimated_opened_for_business: daterange, express_updated_at: time, facebook_url: string, fax_number: string, federal_government_contractor: boolean, fips_code: string, fiscal_year_end_month: string, foreign_parent_flag: boolean, fortune_ranking: integer, foursquare_url: string, geocoordinate: geopoint, geo_match_level: string, greenscore: integer, growing_business_code: string, has_ecommerce: boolean, headquarters_id: string, historical_names: array, historical_names_count: integer, hospital_has_emergency_room: boolean, in_business: string, in_business_on: date, infogroup_id: string, instagram_url: string, insurances_accepted: array, insurances_accepted_count: integer, landmark_address: string, languages_spoken: array, languages_spoken_count: integer, latitude: float, legal_name: string, legal_names: array, legal_names_count: integer, linked_in_url: string, location_email_address: string, location_employee_count: integer, location_parent_id: string, location_parent_relationship: string, location_professional_size_code: string, location_sales_volume: integer, logo_url: string, longitude: float, mailing_address: string, mailing_address_carrier_route_code: string, mailing_address_city: string, mailing_address_cmra_flag: boolean, mailing_address_delivery_point_bar_code: string, mailing_address_postal_code: string, mailing_address_score_code: string, mailing_address_state: string, mailing_address_type_code: string, mailing_address_zip: string, mailing_address_zip_four: string, mailing_score_code: string, manual_geocoordinate: geopoint, medicaid_accepted: boolean, medical_dea_number: string, medicare_accepted: boolean, naics_code_ids: array, naics_code_ids_count: integer, name: string, nbrc_corporate_date: date, nbrc_corporation_filing_type: string, number_of_tenants: integer, opened_for_business_on: date, operating_hours_description: string, operating_status: string, out_of_business_on: date, ownership_changed_on: date, payment_types: array, payment_types_count: integer, phone: string, phone_call_status_code: string, physician_year_of_birth: integer, physician_year_of_graduation: integer, pinterest_url: string, place_type: string, population_code_for_zip: string, population_density: float, postal_code: string, price_range: string, primary_naics_code_id: string, primary_sic_code_id: string, professional_specialty_ids: array, professional_specialty_ids_count: integer, public_access: boolean, record_list_ids: array, record_list_ids_count: integer, religious_denomination_ids: array, religious_denomination_ids_count: integer, reopen_date: date, residency_graduation_year: integer, restaurant_service_type_code: string, seeded_organization_id: string, sgc_division: string, shopping_center_atm: boolean, sic_code_ids: array, sic_code_ids_count: integer, single_platform_url: string, square_footage: string, state: string, status: string, stock_exchange_code: string, stock_ticker_symbol: string, street: string, suite: string, suppressed: boolean, suppressed_fields: array, suppressed_fields_count: integer, teleresearch_update_date: time, temporarily_closed: string, temporarily_closed_on: date, territory: boolean, toll_free_number: string, tumblr_url: string, twitter_url: string, ultimate_headquarters_id: string, upin: string, verification_status: string, verified_on: date, wealthy_area_flag: boolean, website: string, website_keywords: array, website_keywords_count: integer, website_status: string, white_collar_percentage: integer, work_at_home: boolean, yelp_url: string, youtube_url: string, zip: string, zip_four: string, benefit_plans: json, benefit_plans_count: integer, contacts: json, contacts_count: integer, happy_hours: json, happy_hours_count: integer, images: json, images_count: integer, in_business_reasons: json, in_business_reasons_count: integer, location_intents: json, location_intents_count: integer, operating_hours: json, operating_hours_count: integer, ucc_filings: json, ucc_filings_count: integer, tags: json, tags_count: integer, bankruptcy: json, credit: json, hotel: json, expenses: json, limited_operations: json, parking: json, primary_contact: json, restaurant: json, service_area: json)"
```