### PR TITLE
GlobalID no longer used

### DIFF
--- a/lib/superstore.rb
+++ b/lib/superstore.rb
@@ -1,7 +1,6 @@
 require 'active_support/all'
 require 'active_model'
 require 'active_record'
-require 'global_id/identification'
 
 module Superstore
   extend ActiveSupport::Autoload

--- a/superstore.gemspec
+++ b/superstore.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('activemodel', '>= 6.1')
   s.add_runtime_dependency('activerecord', '>= 6.1')
-  s.add_runtime_dependency('globalid')
 
   s.add_development_dependency('bundler')
   s.add_development_dependency('rails', '~> 6.1')


### PR DESCRIPTION
It was mentioned in #57 that globalId was no longer used in this repositiory, so this goes ahead and removes it. 