### PR TITLE
bump version, update license files and authors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2009 Koziarski Software Ltd
+Copyright (c) 2009 Koziarski Software Ltd, 2022 Data Axle Inc
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2011 [Michael Koziarski]
+Copyright (c) 2011 [Michael Koziarski], 2022 [Data Axle Inc]
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/superstore.gemspec
+++ b/superstore.gemspec
@@ -1,9 +1,9 @@
 Gem::Specification.new do |s|
   s.name = 'superstore'
-  s.version = '2.5.0'
+  s.version = '2.5.1'
   s.description = 'ActiveModel-based JSONB document store'
   s.summary = 'ActiveModel for JSONB documents'
-  s.authors = ['Michael Koziarski', 'Infogroup']
+  s.authors = ['Michael Koziarski', 'Data Axle']
   s.email = 'developer@matthewhiggins.com'
   s.homepage = 'http://github.com/data-axle/superstore'
   s.licenses = %w[ISC MIT]

--- a/superstore.gemspec
+++ b/superstore.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'superstore'
-  s.version = '2.5.1'
+  s.version = '3.0.0'
   s.description = 'ActiveModel-based JSONB document store'
   s.summary = 'ActiveModel for JSONB documents'
   s.authors = ['Michael Koziarski', 'Data Axle']


### PR DESCRIPTION
Looks like the changes since last version are:
* remove globalId
* require ruby 3 instead of ruby 2
* require rails 6.1 instead of rails 5.2