### PR TITLE
Support calling `reflect_on_association` on `Superstore::Base` subclasses

### DIFF
--- a/lib/superstore/associations/reflection.rb
+++ b/lib/superstore/associations/reflection.rb
@@ -55,6 +55,10 @@ module Superstore
         options[:inverse_of]
       end
 
+      def parent_reflection
+        nil
+      end
+
       private
 
       def derive_foreign_key

--- a/lib/superstore/associations/reflection.rb
+++ b/lib/superstore/associations/reflection.rb
@@ -56,7 +56,6 @@ module Superstore
       end
 
       def parent_reflection
-        nil
       end
 
       private

--- a/test/unit/associations/reflection_test.rb
+++ b/test/unit/associations/reflection_test.rb
@@ -1,13 +1,11 @@
 require 'test_helper'
 
 class Superstore::Associations::ReflectionTest < Superstore::TestCase
-  # class ::Status < Superstore::Base; end
-  # class ::Job < Superstore::Base
-  #   self.table_name = 'issues'
-  #   belongs_to :status
-  # end
-  #
-  # test 'class_name' do
-  #   assert_equal 'Status', Job.new.association_reflections[:status].class_name
-  # end
+  test 'reflect_on_associations' do
+    assert_equal %i(labels children_issues parent_issue), Issue.reflect_on_all_associations.map(&:name)
+  end
+
+  test 'reflections' do
+    assert_instance_of ActiveRecord::Reflection::HasManyReflection, Issue.reflections['labels']
+  end
 end


### PR DESCRIPTION
### Problem

Calling the Rails methods `reflections` and `reflect_on_association` ([docs](https://api.rubyonrails.org/classes/ActiveRecord/Reflection/ClassMethods.html#method-i-reflect_on_association)) errors on Superstore::Base models:

```
NoMethodError: undefined method `parent_reflection' for #<Superstore::Associations::Reflection:0x00007fec041d1878 @macro=:belongs_to, @name=:headquarters, @model=Place, @options={:class_name=>"Place", :foreign_key=>"headquarters_id"}>
```

### Solution

Define `parent_reflection` as `nil`.