### PR TITLE
Empty arrays are nil

### DIFF
--- a/lib/superstore/types/array_type.rb
+++ b/lib/superstore/types/array_type.rb
@@ -2,7 +2,7 @@ module Superstore
   module Types
     class ArrayType < Base
       def cast_value(value)
-        Array(value)
+        value.present? ? Array(value) : nil
       end
     end
   end

--- a/test/unit/types/array_type_test.rb
+++ b/test/unit/types/array_type_test.rb
@@ -4,6 +4,6 @@ class Superstore::Types::ArrayTypeTest < Superstore::Types::TestCase
   test 'cast_value' do
     assert_equal ['x', 'y'], type.cast_value(['x', 'y'].to_set)
     assert_equal ['x'], type.cast_value('x')
-    assert_nil type.cast_value('x')
+    assert_nil type.cast_value(nil)
   end
 end

--- a/test/unit/types/array_type_test.rb
+++ b/test/unit/types/array_type_test.rb
@@ -5,5 +5,6 @@ class Superstore::Types::ArrayTypeTest < Superstore::Types::TestCase
     assert_equal ['x', 'y'], type.cast_value(['x', 'y'].to_set)
     assert_equal ['x'], type.cast_value('x')
     assert_nil type.cast_value(nil)
+    assert_nil type.cast_value([])
   end
 end

--- a/test/unit/types/array_type_test.rb
+++ b/test/unit/types/array_type_test.rb
@@ -4,5 +4,6 @@ class Superstore::Types::ArrayTypeTest < Superstore::Types::TestCase
   test 'cast_value' do
     assert_equal ['x', 'y'], type.cast_value(['x', 'y'].to_set)
     assert_equal ['x'], type.cast_value('x')
+    assert_nil type.cast_value('x')
   end
 end


### PR DESCRIPTION
[INFO-13814]

## Problem

This works (it shouldn't):

```ruby
place.brand_ids = []
place.brand_ids
# => []
```

## Solution

Make it do this:

```ruby
place.brand_ids = []
place.brand_ids
# => nil
```


[INFO-13814]: https://infogroup.atlassian.net/browse/INFO-13814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ