### PR TITLE
Support Rails 7.1.2

### DIFF
--- a/lib/superstore/persistence.rb
+++ b/lib/superstore/persistence.rb
@@ -7,7 +7,7 @@ module Superstore
         find_by(id: id)
       end
 
-      def _insert_record(attributes)
+      def _insert_record(attributes, _returning = nil)
         adapter.insert(*attributes_for_upsert(attributes.fetch(primary_key), attributes))
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,9 @@ I18n.config.enforce_available_locales = false
 ActiveSupport::TestCase.test_order = :random
 
 require 'active_record'
+
+class DummyApp < Rails::Application; end
+
 require 'rails/test_help'
 require 'mocha/api'
 


### PR DESCRIPTION
## Problem

These 2 recent commits to Rails are causing our test suite to fail.

1. https://github.com/rails/rails/commit/70843ff7b2164030751054b5e873aa7b793ea6ca
2. https://github.com/rails/rails/commit/c92933265efce7faa77767bf7f6ac0532312fd4e

They're causing the below errors:

<details>
<summary> Error caused by 1 </summary>

```
/Users/matthi/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/railties-7.1.2/lib/rails.rb:51:in `configuration': undefined method `config' for nil:NilClass (NoMethodError)

      application.config
                 ^^^^^^^
        from /Users/matthi/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/railties-7.1.2/lib/rails/testing/maintain_test_schema.rb:11:in `<top (required)>'
        from /Users/matthi/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/railties-7.1.2/lib/rails/test_help.rb:17:in `require'
        from /Users/matthi/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/railties-7.1.2/lib/rails/test_help.rb:17:in `<top (required)>'
        from /Users/matthi/axle/superstore/test/test_helper.rb:10:in `require'
        from /Users/matthi/axle/superstore/test/test_helper.rb:10:in `<top (required)>'
        from /Users/matthi/axle/superstore/test/unit/active_model_test.rb:1:in `require'
        from /Users/matthi/axle/superstore/test/unit/active_model_test.rb:1:in `<top (required)>'
        from /Users/matthi/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:21:in `require'
        from /Users/matthi/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:21:in `block in <main>'
        from /Users/matthi/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:6:in `select'
        from /Users/matthi/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:6:in `<main>'
rake aborted!
```

</details>

<details>
<summary> Error caused by 2 </summary>

```
E

Error:
Superstore::ScrollingTest#test_scroll_in_batches:
ArgumentError: wrong number of arguments (given 2, expected 1)
    lib/superstore/persistence.rb:10:in `_insert_record'
    test/unit/relation/scrolling_test.rb:21:in `block in <class:ScrollingTest>'


bin/rails test test/unit/relation/scrolling_test.rb:20

...

Finished in 0.101188s, 1057.4376 runs/s, 1502.1544 assertions/s.
107 runs, 152 assertions, 0 failures, 49 errors, 0 skips

```

</details>

## Solution

1. Define a dummy app so that `Rails.configuration` doesn't error.
2. Support passing an optional 2nd argument to `_insert_record`.