### PR TITLE
Serialize empty arrays to `nil`; don't cast them

### DIFF
--- a/lib/superstore/types/array_type.rb
+++ b/lib/superstore/types/array_type.rb
@@ -1,8 +1,12 @@
 module Superstore
   module Types
     class ArrayType < Base
+      def serialize(value)
+        value if value.present?
+      end
+
       def cast_value(value)
-        value.present? ? Array(value) : nil
+        Array(value)
       end
     end
   end

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -10,6 +10,7 @@ class Issue < Superstore::Base
   attribute :title, type: :string
   attribute :parent_issue_id, type: :string
   attribute :comments, type: :json
+  attribute :tags, type: :array
   attribute :created_at, type: :time
   attribute :updated_at, type: :time
 

--- a/test/unit/core_test.rb
+++ b/test/unit/core_test.rb
@@ -44,7 +44,7 @@ class Superstore::CoreTest < Superstore::TestCase
   end
 
   test 'inspect class' do
-    expected = "Issue(widget_id: integer, id: string, description: string, title: string, parent_issue_id: string, comments: json, created_at: time, updated_at: time)"
+    expected = "Issue(widget_id: integer, id: string, description: string, title: string, parent_issue_id: string, comments: json, tags: array, created_at: time, updated_at: time)"
     assert_equal expected, Issue.inspect
   end
 end

--- a/test/unit/serialization_test.rb
+++ b/test/unit/serialization_test.rb
@@ -9,6 +9,7 @@ class Superstore::SerializationTest < Superstore::TestCase
       "created_at"  => nil,
       "updated_at"  => nil,
       "description" => nil,
+      "tags"        => nil,
       "title"       => nil,
       "parent_issue_id" => nil,
       "comments"    => nil

--- a/test/unit/types/array_type_test.rb
+++ b/test/unit/types/array_type_test.rb
@@ -8,7 +8,7 @@ class Superstore::Types::ArrayTypeTest < Superstore::Types::TestCase
     assert_equal [], type.cast_value(nil)
   end
 
-  test 'persistence' do
+  test 'serializes empty array to nil' do
     tags   = %w(foo bar)
     issue1 = Issue.new(tags:)
     issue2 = Issue.new(tags: [])

--- a/test/unit/types/array_type_test.rb
+++ b/test/unit/types/array_type_test.rb
@@ -4,6 +4,7 @@ class Superstore::Types::ArrayTypeTest < Superstore::Types::TestCase
   test 'cast_value' do
     assert_equal ['x', 'y'], type.cast_value(['x', 'y'].to_set)
     assert_equal ['x'], type.cast_value('x')
+    assert_equal [], type.cast_value([])
     assert_equal [], type.cast_value(nil)
   end
 

--- a/test/unit/types/array_type_test.rb
+++ b/test/unit/types/array_type_test.rb
@@ -4,7 +4,20 @@ class Superstore::Types::ArrayTypeTest < Superstore::Types::TestCase
   test 'cast_value' do
     assert_equal ['x', 'y'], type.cast_value(['x', 'y'].to_set)
     assert_equal ['x'], type.cast_value('x')
-    assert_nil type.cast_value(nil)
-    assert_nil type.cast_value([])
+    assert_equal [], type.cast_value(nil)
+  end
+
+  test 'persistence' do
+    tags   = %w(foo bar)
+    issue1 = Issue.new(tags:)
+    issue2 = Issue.new(tags: [])
+
+    assert_equal tags, issue1.tags
+    assert_equal [], issue2.tags
+
+    [issue1, issue2].each(&:save!).each(&:reload)
+
+    assert_equal tags, issue1.tags
+    assert_nil issue2.tags
   end
 end


### PR DESCRIPTION
2nd pass at [INFO-13814](https://infogroup.atlassian.net/browse/INFO-13814) after https://github.com/data-axle/content_system/pull/8417#discussion_r1419771351

This PR reverts https://github.com/data-axle/superstore/commit/695f7b954d8f7ccb3fd58b85984809a87d248bc4 and adds some additional features.

## Problem

Casting empty arrays to `nil` means that we can't do things like the following:

```ruby
document.record_list_ids ||= []
```

## Solution

Support empty arrays in memory for array attributes.

In technical terms: Instead of modifying `cast_value`, hook into the `serialize` method. 

[INFO-13814]: https://infogroup.atlassian.net/browse/INFO-13814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ