### PR TITLE
JSON: serialize empty arrays to `nil`

### DIFF
--- a/lib/superstore/types/json_type.rb
+++ b/lib/superstore/types/json_type.rb
@@ -1,6 +1,9 @@
 module Superstore
   module Types
     class JsonType < Base
+      def serialize(value)
+        value if value.present?
+      end
     end
   end
 end

--- a/test/unit/types/json_type_test.rb
+++ b/test/unit/types/json_type_test.rb
@@ -1,4 +1,20 @@
 require 'test_helper'
 
 class Superstore::Types::JsonTypeTest < Superstore::Types::TestCase
+  test 'serializes empty array to nil' do
+    comments = { 'foo' => 'bar' }
+    issue1   = Issue.new(comments:)
+    issue2   = Issue.new(comments: [])
+    issue3   = Issue.new(comments: {})
+
+    assert_equal comments, issue1.comments
+    assert_equal [], issue2.comments
+    assert_equal({}, issue3.comments)
+
+    [issue1, issue2].each(&:save!).each(&:reload)
+
+    assert_equal comments, issue1.comments
+    assert_nil issue2.comments
+    assert_equal({}, issue3.comments)
+  end
 end

--- a/test/unit/types/json_type_test.rb
+++ b/test/unit/types/json_type_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class Superstore::Types::JsonTypeTest < Superstore::Types::TestCase
-  test 'serializes empty array to nil' do
+  test 'serializes empty json to nil' do
     comments = { 'foo' => 'bar' }
     issue1   = Issue.new(comments:)
     issue2   = Issue.new(comments: [])
@@ -11,10 +11,10 @@ class Superstore::Types::JsonTypeTest < Superstore::Types::TestCase
     assert_equal [], issue2.comments
     assert_equal({}, issue3.comments)
 
-    [issue1, issue2].each(&:save!).each(&:reload)
+    [issue1, issue2, issue3].each(&:save!).each(&:reload)
 
     assert_equal comments, issue1.comments
     assert_nil issue2.comments
-    assert_equal({}, issue3.comments)
+    assert_nil issue3.comments
   end
 end


### PR DESCRIPTION
## Problem

In 85ef44b we changed Array types so that empty arrays are serialized to the database as `nil`. However, we didn't do this for JSON types, which is the type used by `nest_many` attributes.

## Solution

Serialize empty arrays as `nil` to the database. 

For Platform this means that update statements go from this:

```SQL
UPDATE "places"
SET "document" = ((document - 'primary_contact') || '{"contacts":[],"contacts_count":0,"updated_at":"2024-01-16T23:44:48.913779Z","extended_contacts_count":0}')
WHERE id = '427622700'
```

to this:

```SQL
UPDATE "places"
SET "document" = ((((document - 'contacts') - 'contacts_count') - 'primary_contact') || '{"updated_at":"2024-01-17T00:50:33.987526Z","extended_contacts_count":0}')
WHERE id = '427622700'
```