### PR TITLE
Improved `_assign_attribute` implementation

### DIFF
--- a/lib/superstore/attribute_assignment.rb
+++ b/lib/superstore/attribute_assignment.rb
@@ -1,7 +1,12 @@
 module Superstore
   module AttributeAssignment
     def _assign_attribute(k, v)
-      public_send("#{k}=", v) if respond_to?("#{k}=")
+      setter = :"#{k}="
+      public_send(setter, v)
+    rescue NoMethodError
+      if respond_to?(setter)
+        raise
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem

See [this commit](https://github.com/rails/rails/commit/7a9a537e9d7542cbfeb928ca6fd0e993b8a4d94f) in Rails. My own performance testing indicates that Platform DataImport performance is impacted by the described behavior.

## Solution

Borrow from the more-performant, latest `ActiveModel` implementation of `_assign_attribute`. I tried removing this method override entirely at first and just relying on the ActiveModel implementation directly, but it turns out we're pretty reliant upon the "fail silently" behavior achieved by the `respond_to?` check.